### PR TITLE
Improve task config and command

### DIFF
--- a/docs/mkdocs/guides/pipeline.md
+++ b/docs/mkdocs/guides/pipeline.md
@@ -67,7 +67,7 @@ tasks:
       gpus: 1
       memory: 8G
       time: 02:00:00
-      extra_options:
+      sbatch_options:
         - "--mail-user=sp8538@princeton.edu"
     setup_commands:
       - module purge

--- a/docs/mkdocs/guides/task.md
+++ b/docs/mkdocs/guides/task.md
@@ -205,7 +205,7 @@ Calling `Transcribe.cli()` turns this module into a runnable CLI application:
     │ *  --memory                TEXT     Memory per worker [required]                       │
     │ *  --time                  TEXT     Wall time per worker [required]                    │
     │    --gpus                  INTEGER  Number of GPUs per worker                          │
-    │    --extra-option          TEXT     Additional Slurm option for workers (repeatable)   │
+    │    --sbatch-option         TEXT     Additional Slurm option for workers (repeatable)   │
     │    --setup-command         TEXT     Shell command to run before the task starts        │
     │                                     (repeatable)                                       │
     │    --task-name             TEXT     Task name [default: Transcribe]                    │
@@ -229,7 +229,7 @@ We can then run the task as follows:
     --memory "12G" \
     --time "02:00:00" \
     --gpus 1 \
-    --extra-option "--mail-user=sp8538@princeton.edu" \
+    --sbatch-option "--mail-user=sp8538@princeton.edu" \
     --setup-command "module purge" \
     --setup-command "module load anaconda3/2024.6" \
     --setup-command "conda activate tiktok"

--- a/src/tigerflow/models.py
+++ b/src/tigerflow/models.py
@@ -29,7 +29,7 @@ class SlurmResourceConfig(BaseModel):
     gpus: int | None = None
     memory: str
     time: str
-    extra_options: list[str] = []
+    sbatch_options: list[str] = []
 
 
 class BaseTaskConfig(BaseModel):
@@ -189,8 +189,8 @@ class SlurmTaskConfig(BaseTaskConfig):
                 "--run-directly",
             ]
             + [
-                f"--extra-option {repr(option)}"
-                for option in self.worker_resources.extra_options
+                f"--sbatch-option {repr(option)}"
+                for option in self.worker_resources.sbatch_options
             ]
             + [f"--setup-command {repr(command)}" for command in self.setup_commands]
         )

--- a/src/tigerflow/tasks/slurm.py
+++ b/src/tigerflow/tasks/slurm.py
@@ -87,7 +87,7 @@ class SlurmTask(Task):
             memory=self.config.worker_resources.memory,
             walltime=self.config.worker_resources.time,
             processes=1,
-            job_extra_directives=self.config.worker_resources.extra_options
+            job_extra_directives=self.config.worker_resources.sbatch_options
             + [
                 f"--job-name={self.config.worker_job_name}",
                 f"--output={self.config.log_dir}/%x-%j.out",
@@ -217,10 +217,10 @@ class SlurmTask(Task):
                     help="Number of GPUs per worker",
                 ),
             ] = None,
-            extra_options: Annotated[
+            sbatch_options: Annotated[
                 list[str],
                 typer.Option(
-                    "--extra-option",
+                    "--sbatch-option",
                     help="Additional Slurm option for workers (repeatable)",
                 ),
             ] = [],
@@ -257,7 +257,7 @@ class SlurmTask(Task):
                 gpus=gpus,
                 memory=memory,
                 time=time,
-                extra_options=extra_options,
+                sbatch_options=sbatch_options,
             )
 
             config = SlurmTaskConfig(


### PR DESCRIPTION
### Changes

- Users must specify which account to charge for Slurm tasks
- Users can pass arbitrary sbatch options (e.g., `--mail-user`)
- Make clearer that the resources specified in a Slurm task is for each worker, not the entire task
- Multiple options/commands are passed as a list (rather than a single semicolon-separated string)
  - This helps to avoid a potential bug in identifying each individual option/command
- Update docs to reflect these changes

### Issues Resolved

- #15
- #20