### PR TITLE
Remove `account` field from Slurm task config

### DIFF
--- a/docs/mkdocs/guides/pipeline.md
+++ b/docs/mkdocs/guides/pipeline.md
@@ -53,7 +53,6 @@ tasks:
     module: ./transcribe.py
     input_ext: .mp4
     output_ext: .txt
-    account: sp8538
     max_workers: 3
     worker_resources:
       cpus: 1
@@ -97,7 +96,6 @@ where:
 - `depends_on` specifies the name of the parent task whose output is used as input for the current task.
 - `keep_output` specifies whether to retain output files from the current task. If unspecified, it defaults to `true`.
 - `setup_commands` specifies a list of Bash commands to run before starting the task. This can be used to activate a virtual environment required for the task logic.
-- `account` is a field applicable only to Slurm tasks. It specifies the account to charge for resource usage.
 - `max_workers` is a field applicable only to Slurm tasks. It specifies the maximum number of parallel workers used for auto-scaling.
 - `worker_resources` is a section applicable only to Slurm tasks. It specifies compute, memory, and other resources to allocate for each worker.
 - `concurrency_limit` is a field applicable only to local asynchronous tasks. It specifies the maximum number of coroutines (e.g., API requests) that may run concurrently at any given time (excess coroutines are queued until capacity becomes available).

--- a/docs/mkdocs/guides/task.md
+++ b/docs/mkdocs/guides/task.md
@@ -199,7 +199,6 @@ Calling `Transcribe.cli()` turns this module into a runnable CLI application:
     │ *  --input-ext             TEXT     Input file extension [required]                    │
     │ *  --output-dir            PATH     Output directory to store results [required]       │
     │ *  --output-ext            TEXT     Output file extension [required]                   │
-    │ *  --account               TEXT     Account to charge resources [required]             │
     │ *  --max-workers           INTEGER  Max number of workers for autoscaling [required]   │
     │ *  --cpus                  INTEGER  Number of CPUs per worker [required]               │
     │ *  --memory                TEXT     Memory per worker [required]                       │
@@ -223,7 +222,6 @@ We can then run the task as follows:
     --input-ext .mp4 \
     --output-dir path/to/results/ \
     --output-ext .txt \
-    --account sp8538 \
     --max-workers 3 \
     --cpus 1 \
     --memory "12G" \

--- a/src/tigerflow/models.py
+++ b/src/tigerflow/models.py
@@ -156,7 +156,6 @@ class LocalAsyncTaskConfig(BaseTaskConfig):
 
 class SlurmTaskConfig(BaseTaskConfig):
     kind: Literal["slurm"]
-    account: str
     max_workers: int
     worker_resources: SlurmResourceConfig
 
@@ -183,7 +182,6 @@ class SlurmTaskConfig(BaseTaskConfig):
                 f"--input-ext {self.input_ext}",
                 f"--output-dir {self.output_dir}",
                 f"--output-ext {self.output_ext}",
-                f"--account {self.account}",
                 f"--max-workers {self.max_workers}",
                 f"--cpus {self.worker_resources.cpus}",
                 f"--memory {self.worker_resources.memory}",
@@ -202,7 +200,6 @@ class SlurmTaskConfig(BaseTaskConfig):
 
         script = textwrap.dedent(f"""\
             #!/bin/bash
-            #SBATCH --account={self.account}
             #SBATCH --job-name={self.client_job_name}
             #SBATCH --output={self.log_dir}/%x-%j.out
             #SBATCH --error={self.log_dir}/%x-%j.err

--- a/src/tigerflow/tasks/slurm.py
+++ b/src/tigerflow/tasks/slurm.py
@@ -83,7 +83,6 @@ class SlurmTask(Task):
 
         # Define parameters for each Slurm job
         cluster = SLURMCluster(
-            account=self.config.account,
             cores=self.config.worker_resources.cpus,
             memory=self.config.worker_resources.memory,
             walltime=self.config.worker_resources.time,
@@ -178,13 +177,6 @@ class SlurmTask(Task):
                     show_default=False,
                 ),
             ],
-            account: Annotated[
-                str,
-                typer.Option(
-                    help="Account to charge resources",
-                    show_default=False,
-                ),
-            ],
             max_workers: Annotated[
                 int,
                 typer.Option(
@@ -269,7 +261,6 @@ class SlurmTask(Task):
                 input_ext=input_ext,
                 output_ext=output_ext,
                 setup_commands=setup_commands,
-                account=account,
                 max_workers=max_workers,
                 worker_resources=worker_resources,
             )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -219,7 +219,6 @@ class TestSlurmTaskConfig:
             module=tmp_module,
             input_ext=".txt",
             output_ext=".json",
-            account="myaccount",
             max_workers=4,
             worker_resources=SlurmResourceConfig(
                 cpus=8,
@@ -241,7 +240,6 @@ class TestSlurmTaskConfig:
     def test_to_script_contains_sbatch_directives(self, slurm_config: SlurmTaskConfig):
         script = slurm_config.to_script()
 
-        assert "#SBATCH --account=myaccount" in script
         assert "#SBATCH --job-name=slurm_task-client" in script
         assert "#SBATCH --nodes=1" in script
         assert "#SBATCH --ntasks=1" in script
@@ -265,7 +263,6 @@ class TestSlurmTaskConfig:
             kind="slurm",
             module=tmp_module,
             input_ext=".txt",
-            account="myaccount",
             max_workers=2,
             worker_resources=SlurmResourceConfig(
                 cpus=4,
@@ -289,7 +286,6 @@ class TestSlurmTaskConfig:
             kind="slurm",
             module=tmp_module,
             input_ext=".txt",
-            account="myaccount",
             max_workers=2,
             worker_resources=SlurmResourceConfig(
                 cpus=4,


### PR DESCRIPTION
The `--account` sbatch option overrides the default sponsor account charged for cluster usage. Since this account is usually different from the user's own (unless the user is the PI), explicitly setting it can be confusing.

By default, Slurm automatically charges the appropriate sponsor account, which is the recommended behavior. If a user has multiple sponsors and needs to charge a specific one, they can provide the `--account` option through the `sbatch_options` field in Slurm task config.

(Thanks @Nina-mvH for spotting this issue!)