### PR TITLE
Add a log message informing completion of all staged files

### DIFF
--- a/docs/mkdocs/guides/pipeline.md
+++ b/docs/mkdocs/guides/pipeline.md
@@ -143,6 +143,7 @@ we can run the pipeline as follows:
     2025-09-22 09:23:05 | INFO     | Completed processing 4 file(s)
     2025-09-22 09:23:15 | INFO     | Completed processing 6 file(s)
     2025-09-22 09:23:55 | INFO     | Completed processing 1 file(s)
+    2025-09-22 09:23:55 | INFO     | No more files to process, starting idle time count
     2025-09-22 09:25:06 | INFO     | [transcribe] Status changed: ACTIVE (3 workers) -> ACTIVE (1 workers)
     2025-09-22 09:25:46 | INFO     | [transcribe] Status changed: ACTIVE (1 workers) -> ACTIVE (0 workers)
     2025-09-22 09:33:48 | WARNING  | Idle timeout reached, initiating shutdown

--- a/src/tigerflow/pipeline.py
+++ b/src/tigerflow/pipeline.py
@@ -310,12 +310,15 @@ class Pipeline:
             self._finished_dir.joinpath(filename).touch()
         if completed_file_ids:
             logger.info("Completed processing {} files", len(completed_file_ids))
+            n_finished = sum(1 for f in self._finished_dir.iterdir() if f.is_file())
+            n_failed = sum(len(errs) for errs in self._task_error_filenames.values())
+            if (n_finished + n_failed) >= len(self._filenames):
+                logger.info("No more files to process, starting idle time count")
 
     def _check_inactivity(self):
         n_finished = sum(1 for file in self._finished_dir.iterdir() if file.is_file())
-        n_failed = sum(len(errors) for errors in self._task_error_filenames.values())
-        n_total = len(self._filenames)
-        if (n_finished + n_failed) < n_total:  # Still in progress
+        n_failed = sum(len(errs) for errs in self._task_error_filenames.values())
+        if (n_finished + n_failed) < len(self._filenames):  # Still in progress
             self._last_active = datetime.now()
 
         inactivity = datetime.now() - self._last_active


### PR DESCRIPTION
It is useful for users to know when all staged files have finished processing (whether successful or failed) and when idle time counting begins. Note that staging new files (before timeout) will abort earlier counting for idle time:

```
...
2026-02-03 18:02:22 | INFO     | Completed processing 3 files
2026-02-03 18:02:32 | INFO     | Completed processing 1 files
2026-02-03 18:02:32 | INFO     | No more files to process, starting idle time count
2026-02-03 18:05:22 | INFO     | Staged 1 new files for processing
2026-02-03 18:05:42 | INFO     | Completed processing 1 files
2026-02-03 18:05:42 | INFO     | No more files to process, starting idle time count
2026-02-03 18:15:33 | WARNING  | Idle timeout reached, initiating shutdown
2026-02-03 18:15:33 | INFO     | Shutting down pipeline
...
```