### PR TITLE
Disable nanny in Slurm task workers

### DIFF
--- a/src/tigerflow/tasks/slurm.py
+++ b/src/tigerflow/tasks/slurm.py
@@ -1,3 +1,4 @@
+import asyncio
 import signal
 import subprocess
 import sys
@@ -52,16 +53,18 @@ class SlurmTask(Task):
         teardown_func = type(self).teardown
 
         class TaskWorkerPlugin(WorkerPlugin):
-            def setup(self, worker: Worker):
+            async def setup(self, worker: Worker):
                 logger.info("Setting up task")
                 worker.context = SetupContext()
-                setup_func(worker.context)
+                loop = asyncio.get_running_loop()
+                await loop.run_in_executor(None, setup_func, worker.context)
                 worker.context.freeze()  # Make it read-only
                 logger.info("Task setup complete")
 
-            def teardown(self, worker: Worker):
+            async def teardown(self, worker: Worker):
                 logger.info("Shutting down task")
-                teardown_func(worker.context)
+                loop = asyncio.get_running_loop()
+                await loop.run_in_executor(None, teardown_func, worker.context)
                 logger.info("Task shutdown complete")
 
         def task(input_file: Path, output_file: Path):


### PR DESCRIPTION
By default, `SLURMCluster` launches workers under a nanny process. In this setup, each worker runs as a daemon process managed by the nanny process, which prevents it from spawning its own child processes. This causes failures when running multiprocessing-based code (e.g., vLLM). Setting `nanny=False` launches workers directly as non-daemon processes, allowing them to spawn child processes normally. This is safe in our context because Slurm already manages the worker jobs.

The issue has been discovered by @Nina-mvH and the solution has been found by @cswaney.

The PR also updates code to run Slurm worker setup/teardown in a separate thread because user-defined setup/teardown functions may contain blocking code and running them directly in the event loop would freeze it, causing missed heartbeats.