### PR TITLE
Bump package version to `0.1.0a3`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tigerflow"
-version = "0.1.0a2"
+version = "0.1.0a3"
 description = "Data pipeline framework for Slurm-managed HPC clusters"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -941,7 +941,7 @@ wheels = [
 
 [[package]]
 name = "tigerflow"
-version = "0.1.0a2"
+version = "0.1.0a3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Bump package version to `0.1.0a3` for PyPI publication.