### PR TITLE
Fix CI/CD concurrency group deadlock

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,10 +4,6 @@ on:
   release:
     types: [published]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   UV_VERSION: "0.7.15"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
   workflow_call:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: CI-${{ github.ref }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
When CD calls CI as a reusable workflow, `${{ github.workflow }}` resolves to the caller's name (`"CD"`), not `"CI"`. This caused both workflows to share the same concurrency group, resulting in a deadlock.

This PR fixes this by hardcoding `CI` in `ci.yml`'s concurrency group so it behaves consistently whether run standalone or as a reusable workflow. It also removes the concurrency block from `cd.yml`, where it was a no-op (each release tag is unique, so the group never collides).