### PR TITLE
Parametrize example tasks to reflect realistic use cases

### DIFF
--- a/docs/mkdocs/guides/pipeline.md
+++ b/docs/mkdocs/guides/pipeline.md
@@ -54,6 +54,8 @@ tasks:
     input_ext: .mp4
     output_ext: .txt
     max_workers: 3
+    params:
+      model_file: /home/sp8538/.cache/whisper/medium.pt
     worker_resources:
       cpus: 1
       gpus: 1
@@ -73,6 +75,8 @@ tasks:
     output_ext: .json
     keep_output: false
     concurrency_limit: 10
+    params:
+      model: voyage-4-lite
     setup_commands:
       - module purge
       - module load anaconda3/2024.6
@@ -83,6 +87,8 @@ tasks:
     module: ./ingest.py
     input_ext: .json
     keep_output: false
+    params:
+      db_path: /home/sp8538/tiktok/pipeline/tigerflow/demo/results/test.db
     setup_commands:
       - module purge
       - module load anaconda3/2024.6
@@ -95,13 +101,7 @@ where:
 - `module` specifies the Python module defining task logic. Can be the path to a user-defined task (e.g., `/path/to/transcribe.py`) or the import path of a library task (e.g., `tigerflow.library.echo`). Care should be taken when using a relative file path as it may resolve incorrectly when running the pipeline.
 - `depends_on` specifies the name of the parent task whose output is used as input for the current task.
 - `keep_output` specifies whether to retain output files from the current task. If unspecified, it defaults to `true`.
-- `params` specifies custom parameters to pass to the task (see [Custom Parameters](task.md#custom-parameters)). For example:
-  ```yaml
-  params:
-    model_name: "whisper-large"
-    temperature: 0.5
-    verbose: true
-  ```
+- `params` specifies custom parameters to pass to the task (see [Custom Parameters](task.md#custom-parameters)).
 - `setup_commands` specifies a list of Bash commands to run before starting the task. This can be used to activate a virtual environment required for the task logic.
 - `max_workers` is a field applicable only to Slurm tasks. It specifies the maximum number of parallel workers used for auto-scaling.
 - `worker_resources` is a section applicable only to Slurm tasks. It specifies compute, memory, and other resources to allocate for each worker.

--- a/examples/audio_feature_extraction/code/config.yaml
+++ b/examples/audio_feature_extraction/code/config.yaml
@@ -22,6 +22,8 @@ tasks:
     output_ext: .json
     keep_output: false
     concurrency_limit: 10
+    params:
+      model: voyage-4-lite
   - name: ingest
     depends_on: embed
     kind: local

--- a/examples/audio_feature_extraction/code/embed.py
+++ b/examples/audio_feature_extraction/code/embed.py
@@ -1,11 +1,20 @@
 import asyncio
 from pathlib import Path
+from typing import Annotated
+
+import typer
 
 from tigerflow.tasks import LocalAsyncTask
 from tigerflow.utils import SetupContext
 
 
 class Embed(LocalAsyncTask):
+    class Params:
+        model: Annotated[
+            str,
+            typer.Option(help="Embedding model name"),
+        ] = "voyage-3.5"
+
     @staticmethod
     async def setup(context: SetupContext):
         import os
@@ -32,7 +41,7 @@ class Embed(LocalAsyncTask):
             headers=context.headers,
             json={
                 "input": text.strip(),
-                "model": "voyage-3.5",
+                "model": context.model,
                 "input_type": "document",
             },
         ) as resp:

--- a/examples/audio_feature_extraction/code/ingest.py
+++ b/examples/audio_feature_extraction/code/ingest.py
@@ -1,5 +1,8 @@
 import json
 from pathlib import Path
+from typing import Annotated
+
+import typer
 
 from tigerflow.tasks import LocalTask
 from tigerflow.utils import SetupContext
@@ -8,12 +11,18 @@ DB_PATH = Path(__file__).parent.parent / "results" / "test.db"
 
 
 class Ingest(LocalTask):
+    class Params:
+        db_path: Annotated[
+            Path,
+            typer.Option(help="Path to the DuckDB database file"),
+        ] = DB_PATH
+
     @staticmethod
     def setup(context: SetupContext):
         import duckdb
 
-        conn = duckdb.connect(DB_PATH)  # Creates file if not existing
-        print(f"Successfully connected to {DB_PATH}")
+        conn = duckdb.connect(str(context.db_path))  # Creates file if not existing
+        print(f"Successfully connected to {context.db_path}")
 
         conn.execute("""
             CREATE TABLE IF NOT EXISTS embeddings (

--- a/examples/audio_feature_extraction/code/transcribe.py
+++ b/examples/audio_feature_extraction/code/transcribe.py
@@ -1,17 +1,26 @@
 from pathlib import Path
+from typing import Annotated
+
+import typer
 
 from tigerflow.tasks import SlurmTask
 from tigerflow.utils import SetupContext
 
-MODEL_PATH = Path(__file__).parent.parent / "models" / "whisper" / "medium.pt"
+MODEL_FILE = Path(__file__).parent.parent / "models" / "whisper" / "medium.pt"
 
 
 class Transcribe(SlurmTask):
+    class Params:
+        model_file: Annotated[
+            Path,
+            typer.Option(help="Path to the Whisper model file"),
+        ] = MODEL_FILE
+
     @staticmethod
     def setup(context: SetupContext):
         import whisper
 
-        context.model = whisper.load_model(MODEL_PATH)
+        context.model = whisper.load_model(str(context.model_file))
         print("Model loaded successfully")
 
     @staticmethod


### PR DESCRIPTION
The existing example tasks (`Transcribe`, `Embed`, and `Ingest`) can be parametrized to reflect more realistic use cases. Update the corresponding pipeline config accordingly.