### PR TITLE
Prepare `v0.2.0` release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,7 @@ repos:
         language: system
         types: [python]
         pass_filenames: false
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    rev: 0.10.4
+    hooks:
+      - id: uv-lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,8 @@ version = "0.1.0a3"
 description = "Data pipeline framework for Slurm-managed HPC clusters"
 readme = "README.md"
 authors = [
-    { name = "Sangyoon Park", email = "datumvitae@gmail.com" }
+    { name = "Sangyoon Park", email = "datumvitae@gmail.com" },
+    { name = "Colin Swaney", email = "colinswaney@princeton.edu" },
 ]
 license = "MIT"
 license-files = ["LICENSE"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tigerflow"
-version = "0.1.0a3"
+version = "0.2.0"
 description = "Data pipeline framework for Slurm-managed HPC clusters"
 readme = "README.md"
 authors = [

--- a/src/tigerflow/tasks/local.py
+++ b/src/tigerflow/tasks/local.py
@@ -141,7 +141,7 @@ class LocalTask(Task):
                     help="Task name",
                 ),
             ] = cls.get_name(),
-            _params: dict = {},
+            _params: dict | None = None,
         ):
             """
             Run the task as a CLI application
@@ -152,7 +152,7 @@ class LocalTask(Task):
                 module=cls.get_module_path(),
                 input_ext=input_ext,
                 output_ext=output_ext,
-                params=_params,
+                params=_params or {},
             )
 
             task = cls(config)

--- a/src/tigerflow/tasks/local_async.py
+++ b/src/tigerflow/tasks/local_async.py
@@ -183,7 +183,7 @@ class LocalAsyncTask(Task):
                     help="Task name",
                 ),
             ] = cls.get_name(),
-            _params: dict = {},
+            _params: dict | None = None,
         ):
             """
             Run the task as a CLI application
@@ -195,7 +195,7 @@ class LocalAsyncTask(Task):
                 input_ext=input_ext,
                 output_ext=output_ext,
                 concurrency_limit=concurrency_limit,
-                params=_params,
+                params=_params or {},
             )
 
             task = cls(config)

--- a/src/tigerflow/tasks/slurm.py
+++ b/src/tigerflow/tasks/slurm.py
@@ -227,19 +227,19 @@ class SlurmTask(Task):
                 ),
             ] = None,
             sbatch_options: Annotated[
-                list[str],
+                list[str] | None,
                 typer.Option(
                     "--sbatch-option",
                     help="Additional Slurm option for workers (repeatable)",
                 ),
-            ] = [],
+            ] = None,
             setup_commands: Annotated[
-                list[str],
+                list[str] | None,
                 typer.Option(
                     "--setup-command",
                     help="Shell command to run before the task starts (repeatable)",
                 ),
-            ] = [],
+            ] = None,
             task_name: Annotated[
                 str,
                 typer.Option(
@@ -257,7 +257,7 @@ class SlurmTask(Task):
                     hidden=True,  # Internal use only
                 ),
             ] = False,
-            _params: dict = {},
+            _params: dict | None = None,
         ):
             """
             Run the task as a CLI application
@@ -267,7 +267,7 @@ class SlurmTask(Task):
                 gpus=gpus,
                 memory=memory,
                 time=time,
-                sbatch_options=sbatch_options,
+                sbatch_options=sbatch_options or [],
             )
 
             config = SlurmTaskConfig(
@@ -276,10 +276,10 @@ class SlurmTask(Task):
                 module=cls.get_module_path(),
                 input_ext=input_ext,
                 output_ext=output_ext,
-                setup_commands=setup_commands,
+                setup_commands=setup_commands or [],
                 max_workers=max_workers,
                 worker_resources=worker_resources,
-                params=_params,
+                params=_params or {},
             )
 
             if run_directly:

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -1002,7 +1002,7 @@ wheels = [
 
 [[package]]
 name = "tigerflow"
-version = "0.1.0a3"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Make final minor updates before `v0.2.0` release:
- Replace mutable default arguments with `None`
- Add a hook to sync `pyproject.toml` with `uv.lock`
- Add Colin as a co-author
- Bump package version to 0.2.0