### PR TITLE
Fix temp files leaking to downstream tasks

### DIFF
--- a/src/tigerflow/models.py
+++ b/src/tigerflow/models.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from tigerflow.settings import settings
 from tigerflow.staging import StagingPipeline
-from tigerflow.utils import validate_file_ext
+from tigerflow.utils import TEMP_FILE_PREFIX, validate_file_ext
 
 
 class TaskStatusKind(Enum):
@@ -417,7 +417,7 @@ class PipelineOutput:
                 task = TaskProgress(name=folder.name)
                 for file in folder.iterdir():
                     if file.is_file():
-                        if file.suffix == "":
+                        if file.name.startswith(TEMP_FILE_PREFIX):
                             task.ongoing.add(file)
                         elif file.name.endswith(".err"):
                             task.failed.add(file)

--- a/src/tigerflow/pipeline.py
+++ b/src/tigerflow/pipeline.py
@@ -23,7 +23,7 @@ from tigerflow.models import (
 from tigerflow.settings import settings
 from tigerflow.staging import StagingContext
 from tigerflow.tasks.utils import get_slurm_task_status
-from tigerflow.utils import is_valid_task_cli, submit_to_slurm
+from tigerflow.utils import TEMP_FILE_PREFIX, is_valid_task_cli, submit_to_slurm
 
 
 class Pipeline:
@@ -112,7 +112,10 @@ class Pipeline:
         # Clean up any invalid or unsuccessful task outputs
         for task in self._config.tasks:
             for file in task.output_dir.iterdir():
-                if file.is_file() and not file.name.endswith(task.output_ext):
+                if file.is_file() and (
+                    not file.name.endswith(task.output_ext)
+                    or file.name.startswith(TEMP_FILE_PREFIX)
+                ):
                     file.unlink()
 
         # Initialize a set to track files being processed or already processed
@@ -133,7 +136,11 @@ class Pipeline:
         for task in self._config.tasks:
             processed_filenames: set[str] = set()
             for file in task.output_dir.iterdir():
-                if file.is_file() and file.name.endswith(task.output_ext):
+                if (
+                    file.is_file()
+                    and file.name.endswith(task.output_ext)
+                    and not file.name.startswith(TEMP_FILE_PREFIX)
+                ):
                     processed_filenames.add(file.name)
             self._task_processed_filenames[task.name] = processed_filenames
 
@@ -302,6 +309,7 @@ class Pipeline:
                 if (
                     file.is_file()
                     and file.name.endswith(".err")
+                    and not file.name.startswith(TEMP_FILE_PREFIX)
                     and file.name not in self._task_error_filenames[task.name]
                 ):
                     self._task_error_filenames[task.name].add(file.name)
@@ -319,6 +327,7 @@ class Pipeline:
                 if (
                     file.is_file()
                     and file.name.endswith(task.output_ext)
+                    and not file.name.startswith(TEMP_FILE_PREFIX)
                     and file.name not in self._task_processed_filenames[task.name]
                 ):
                     self._task_processed_filenames[task.name].add(file.name)

--- a/src/tigerflow/tasks/_base.py
+++ b/src/tigerflow/tasks/_base.py
@@ -4,6 +4,8 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import get_type_hints
 
+from tigerflow.utils import TEMP_FILE_PREFIX
+
 
 class Task(ABC):
     @classmethod
@@ -96,11 +98,8 @@ class Task(ABC):
 
     @staticmethod
     def _remove_temporary_files(dirpath: Path):
-        """
-        Remove any files with no file extension.
-        """
         for file in dirpath.iterdir():
-            if file.is_file() and file.suffix == "":
+            if file.is_file() and file.name.startswith(TEMP_FILE_PREFIX):
                 file.unlink()
 
     @staticmethod
@@ -124,7 +123,9 @@ class Task(ABC):
             file.name.removesuffix(ext)
             for file in output_dir.iterdir()
             for ext in (output_ext, ".err")
-            if file.is_file() and file.name.endswith(ext)
+            if file.is_file()
+            and file.name.endswith(ext)
+            and not file.name.startswith(TEMP_FILE_PREFIX)
         }
 
         unprocessed_files = [
@@ -132,6 +133,7 @@ class Task(ABC):
             for file in input_dir.iterdir()
             if file.is_file()
             and file.name.endswith(input_ext)
+            and not file.name.startswith(TEMP_FILE_PREFIX)
             and file.name.removesuffix(input_ext) not in processed_ids
         ]
 

--- a/src/tigerflow/tasks/slurm.py
+++ b/src/tigerflow/tasks/slurm.py
@@ -20,7 +20,12 @@ from tigerflow.models import (
     TaskStatusKind,
 )
 from tigerflow.settings import settings
-from tigerflow.utils import SetupContext, atomic_write, submit_to_slurm
+from tigerflow.utils import (
+    TEMP_FILE_PREFIX,
+    SetupContext,
+    atomic_write,
+    submit_to_slurm,
+)
 
 from ._base import Task
 from .utils import get_slurm_task_status
@@ -428,6 +433,7 @@ class SlurmTaskRunner:
             if (
                 file.is_file()
                 and file.name.endswith(self.config.output_ext)
+                and not file.name.startswith(TEMP_FILE_PREFIX)
                 and file.name not in self._processed_filenames
             ):
                 self._processed_filenames.add(file.name)
@@ -441,6 +447,7 @@ class SlurmTaskRunner:
             if (
                 file.is_file()
                 and file.name.endswith(".err")
+                and not file.name.startswith(TEMP_FILE_PREFIX)
                 and file.name not in self._error_filenames
             ):
                 self._error_filenames.add(file.name)

--- a/src/tigerflow/utils.py
+++ b/src/tigerflow/utils.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from subprocess import TimeoutExpired
 from types import SimpleNamespace
 
+TEMP_FILE_PREFIX = ".~tf_"
+
 
 def get_version() -> str:
     from importlib.metadata import PackageNotFoundError, version
@@ -183,16 +185,23 @@ def has_running_pid(pid_file: Path) -> bool:
 
 
 @contextmanager
-def atomic_write(filepath: os.PathLike):
+def atomic_write(filepath: str | os.PathLike[str]):
     """
     Context manager for atomic writing:
-    1. Creates a temporary file
+    1. Creates a temporary file with the target's suffix
+       (so libraries that inspect the extension behave correctly)
+       and a distinguishable prefix (so downstream tasks that
+       match on extension alone won't pick it up prematurely)
     2. Yields its path for writing
     3. Atomically replaces the target file on success
     """
     filepath = Path(filepath)
 
-    fd, temp_path = tempfile.mkstemp(dir=filepath.parent)
+    fd, temp_path = tempfile.mkstemp(
+        prefix=TEMP_FILE_PREFIX,
+        suffix=filepath.suffix,
+        dir=filepath.parent,
+    )
     os.close(fd)
 
     temp_path = Path(temp_path)

--- a/tests/unit/test_tasks.py
+++ b/tests/unit/test_tasks.py
@@ -1,10 +1,12 @@
 import inspect
+from pathlib import Path
 from typing import Annotated
 
 import pytest
 import typer
 
 from tigerflow.tasks._base import Task
+from tigerflow.utils import TEMP_FILE_PREFIX
 
 
 class TestGetParamsFromClass:
@@ -172,3 +174,134 @@ class TestBuildCli:
         assert "MyTask.Params" in error_msg
         assert "input_dir" in error_msg
         assert "reserved" in error_msg
+
+
+class TestRemoveTemporaryFiles:
+    def test_removes_files_with_temp_prefix(self, tmp_path: Path):
+        temp = tmp_path / f"{TEMP_FILE_PREFIX}abc123.csv"
+        temp.write_text("partial")
+        normal = tmp_path / "data.csv"
+        normal.write_text("real")
+
+        Task._remove_temporary_files(tmp_path)
+
+        assert not temp.exists()
+        assert normal.exists()
+
+    def test_ignores_directories(self, tmp_path: Path):
+        subdir = tmp_path / f"{TEMP_FILE_PREFIX}dir"
+        subdir.mkdir()
+
+        Task._remove_temporary_files(tmp_path)
+
+        assert subdir.exists()
+
+    def test_empty_directory(self, tmp_path: Path):
+        Task._remove_temporary_files(tmp_path)  # Should not raise
+
+
+class TestGetUnprocessedFiles:
+    def test_includes_unprocessed_input(self, tmp_path: Path):
+        input_dir = tmp_path / "in"
+        output_dir = tmp_path / "out"
+        input_dir.mkdir()
+        output_dir.mkdir()
+
+        (input_dir / "doc1.txt").write_text("data")
+
+        result = Task._get_unprocessed_files(
+            input_dir=input_dir,
+            input_ext=".txt",
+            output_dir=output_dir,
+            output_ext=".csv",
+        )
+        assert len(result) == 1
+        assert result[0].name == "doc1.txt"
+
+    def test_includes_input_with_temp_output(self, tmp_path: Path):
+        input_dir = tmp_path / "in"
+        output_dir = tmp_path / "out"
+        input_dir.mkdir()
+        output_dir.mkdir()
+
+        (input_dir / "doc1.txt").write_text("data")
+        (output_dir / f"{TEMP_FILE_PREFIX}xyz.csv").write_text("partial")
+
+        result = Task._get_unprocessed_files(
+            input_dir=input_dir,
+            input_ext=".txt",
+            output_dir=output_dir,
+            output_ext=".csv",
+        )
+        assert len(result) == 1
+        assert result[0].name == "doc1.txt"
+
+    def test_includes_input_with_temp_error(self, tmp_path: Path):
+        input_dir = tmp_path / "in"
+        output_dir = tmp_path / "out"
+        input_dir.mkdir()
+        output_dir.mkdir()
+
+        (input_dir / "doc1.txt").write_text("data")
+        (output_dir / f"{TEMP_FILE_PREFIX}xyz.err").write_text("partial err")
+
+        result = Task._get_unprocessed_files(
+            input_dir=input_dir,
+            input_ext=".txt",
+            output_dir=output_dir,
+            output_ext=".csv",
+        )
+        assert len(result) == 1
+        assert result[0].name == "doc1.txt"
+
+    def test_excludes_temp_input(self, tmp_path: Path):
+        input_dir = tmp_path / "in"
+        output_dir = tmp_path / "out"
+        input_dir.mkdir()
+        output_dir.mkdir()
+
+        (input_dir / "doc1.txt").write_text("real")
+        (input_dir / f"{TEMP_FILE_PREFIX}abc.txt").write_text("partial")
+
+        result = Task._get_unprocessed_files(
+            input_dir=input_dir,
+            input_ext=".txt",
+            output_dir=output_dir,
+            output_ext=".csv",
+        )
+        assert len(result) == 1
+        assert result[0].name == "doc1.txt"
+
+    def test_excludes_input_with_final_output(self, tmp_path: Path):
+        input_dir = tmp_path / "in"
+        output_dir = tmp_path / "out"
+        input_dir.mkdir()
+        output_dir.mkdir()
+
+        (input_dir / "doc1.txt").write_text("data")
+        (output_dir / "doc1.csv").write_text("done")
+
+        result = Task._get_unprocessed_files(
+            input_dir=input_dir,
+            input_ext=".txt",
+            output_dir=output_dir,
+            output_ext=".csv",
+        )
+        assert result == []
+
+    def test_excludes_input_with_final_error(self, tmp_path: Path):
+        input_dir = tmp_path / "in"
+        output_dir = tmp_path / "out"
+        input_dir.mkdir()
+        output_dir.mkdir()
+
+        (input_dir / "doc1.txt").write_text("data")
+        (output_dir / "doc1.err").write_text("failed")
+
+        result = Task._get_unprocessed_files(
+            input_dir=input_dir,
+            input_ext=".txt",
+            output_dir=output_dir,
+            output_ext=".csv",
+        )
+        assert result == []

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import pytest
 
 from tigerflow.utils import (
+    TEMP_FILE_PREFIX,
+    atomic_write,
     has_running_pid,
     import_callable,
     is_process_running,
@@ -163,3 +165,39 @@ class TestImportCallable:
     def test_raises_type_error_for_non_callable(self):
         with pytest.raises(TypeError, match="does not resolve to a callable"):
             import_callable("os.path:sep")
+
+
+class TestAtomicWrite:
+    def test_temp_file_has_prefix_and_suffix(self, tmp_path: Path):
+        target = tmp_path / "output.csv"
+        with atomic_write(target) as temp:
+            assert temp.name.startswith(TEMP_FILE_PREFIX)
+            assert temp.suffix == ".csv"
+            temp.write_text("data")
+        assert target.read_text() == "data"
+        assert not temp.exists(), "Temp file should be replaced by target"
+
+    def test_temp_file_no_suffix(self, tmp_path: Path):
+        target = tmp_path / "noext"
+        with atomic_write(target) as temp:
+            assert temp.name.startswith(TEMP_FILE_PREFIX)
+            assert temp.suffix == ""
+            temp.write_text("data")
+        assert target.read_text() == "data"
+
+    def test_temp_file_cleaned_on_error(self, tmp_path: Path):
+        target = tmp_path / "output.txt"
+        with pytest.raises(RuntimeError):
+            with atomic_write(target) as temp:
+                temp.write_text("partial")
+                raise RuntimeError("boom")
+        assert not temp.exists(), "Temp file should be removed on error"
+        assert not target.exists(), "Target should not be created on error"
+
+    def test_accepts_str_path(self, tmp_path: Path):
+        target = tmp_path / "output.json"
+        with atomic_write(str(target)) as temp:
+            assert temp.name.startswith(TEMP_FILE_PREFIX)
+            assert temp.suffix == ".json"
+            temp.write_text("{}")
+        assert target.read_text() == "{}"


### PR DESCRIPTION
Fix bug reported by @jasonbgreenfield.

Libraries like `np.save` auto-append file extensions when the output path lacks one, causing `atomic_write`'s extensionless temp files (e.g., `tmp123`) to spawn sibling files (e.g., `tmp123.npy`) that downstream tasks would discover and process prematurely.

Switch to a prefixed naming convention (`.~tf_<random><suffix>`) so temp files carry the correct extension — preventing library misbehavior — while remaining invisible to all directory scans via prefix filtering.