### PR TITLE
Surface stderr detail in task CLI validation errors

### DIFF
--- a/src/tigerflow/pipeline.py
+++ b/src/tigerflow/pipeline.py
@@ -23,7 +23,7 @@ from tigerflow.models import (
 from tigerflow.settings import settings
 from tigerflow.staging import StagingContext
 from tigerflow.tasks.utils import get_slurm_task_status
-from tigerflow.utils import TEMP_FILE_PREFIX, is_valid_task_cli, submit_to_slurm
+from tigerflow.utils import TEMP_FILE_PREFIX, submit_to_slurm, validate_task_cli
 
 
 class Pipeline:
@@ -66,8 +66,7 @@ class Pipeline:
         )
 
         for task in self._config.tasks:
-            if not is_valid_task_cli(task.module):
-                raise ValueError(f"Invalid task CLI: {task.module}")
+            validate_task_cli(task.module)
 
         # Map task I/O directories from the dependency graph
         for task in self._config.tasks:

--- a/src/tigerflow/utils.py
+++ b/src/tigerflow/utils.py
@@ -65,9 +65,8 @@ def import_callable(ref: str) -> Callable:
     return obj
 
 
-def is_valid_task_cli(module: str, *, timeout: int = 60) -> bool:
-    """
-    Check if the given module is a valid task CLI.
+def validate_task_cli(module: str, *, timeout: int = 60):
+    """Validate that the given module is a valid task CLI.
 
     A valid task CLI runs successfully with --help (exit code 0).
     Task subclasses using the built-in cli() method will have the
@@ -78,6 +77,14 @@ def is_valid_task_cli(module: str, *, timeout: int = 60) -> bool:
     module : str
         Either a file path ending in .py or a fully qualified module name
         (e.g., 'tigerflow.library.echo')
+
+    Raises
+    ------
+    ValueError
+        If the CLI exits with a non-zero code. The error message includes
+        the stderr (or stdout) output from running ``--help``.
+    TimeoutError
+        If the CLI does not respond within the timeout.
     """
     if module.endswith(".py"):
         args = [sys.executable, module, "--help"]
@@ -94,7 +101,11 @@ def is_valid_task_cli(module: str, *, timeout: int = 60) -> bool:
     except TimeoutExpired:
         raise TimeoutError(f"CLI validation timed out after {timeout}s: {module}")
 
-    return result.returncode == 0
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise ValueError(
+            f"Invalid task CLI '{module}' (exit code {result.returncode}):\n{detail}"
+        )
 
 
 def submit_to_slurm(script: str) -> int:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -10,9 +10,9 @@ from tigerflow.utils import (
     has_running_pid,
     import_callable,
     is_process_running,
-    is_valid_task_cli,
     read_pid_file,
     validate_callable_reference,
+    validate_task_cli,
 )
 
 
@@ -59,25 +59,27 @@ class TestTaskCliValidation:
         return script
 
     # File module tests
-    def test_valid_file_module_returns_true(self, valid_cli: Path):
-        assert is_valid_task_cli(str(valid_cli)) is True
+    def test_valid_file_module_passes(self, valid_cli: Path):
+        validate_task_cli(str(valid_cli))  # Should not raise
 
-    def test_file_module_nonzero_exit_returns_false(self, cli_nonzero_exit: Path):
-        assert is_valid_task_cli(str(cli_nonzero_exit)) is False
+    def test_file_module_nonzero_exit_raises_value_error(self, cli_nonzero_exit: Path):
+        with pytest.raises(ValueError, match="Invalid task CLI"):
+            validate_task_cli(str(cli_nonzero_exit))
 
     def test_file_module_timeout_raises_timeout_error(self, cli_slow: Path):
         with pytest.raises(TimeoutError, match="timed out after 1s"):
-            is_valid_task_cli(str(cli_slow), timeout=1)
+            validate_task_cli(str(cli_slow), timeout=1)
 
     def test_custom_timeout(self, valid_cli: Path):
-        assert is_valid_task_cli(str(valid_cli), timeout=5) is True
+        validate_task_cli(str(valid_cli), timeout=5)  # Should not raise
 
     # Library module tests
-    def test_valid_library_module_returns_true(self):
-        assert is_valid_task_cli("tigerflow.library.echo") is True
+    def test_valid_library_module_passes(self):
+        validate_task_cli("tigerflow.library.echo")  # Should not raise
 
-    def test_nonexistent_library_module_returns_false(self):
-        assert is_valid_task_cli("nonexistent.module.path") is False
+    def test_nonexistent_library_module_raises_value_error(self):
+        with pytest.raises(ValueError, match="Invalid task CLI"):
+            validate_task_cli("nonexistent.module.path")
 
 
 class TestPidUtilityFunctions:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -38,8 +38,8 @@ class TestTaskCliValidation:
         script.write_text(
             textwrap.dedent(
                 """
-            import sys
-            sys.exit(1)
+            import nonexistent_package
+            nonexistent_package.run()
             """
             )
         )
@@ -63,8 +63,9 @@ class TestTaskCliValidation:
         validate_task_cli(str(valid_cli))  # Should not raise
 
     def test_file_module_nonzero_exit_raises_value_error(self, cli_nonzero_exit: Path):
-        with pytest.raises(ValueError, match="Invalid task CLI"):
+        with pytest.raises(ValueError, match="Invalid task CLI") as exc_info:
             validate_task_cli(str(cli_nonzero_exit))
+        assert "ModuleNotFoundError" in str(exc_info.value)
 
     def test_file_module_timeout_raises_timeout_error(self, cli_slow: Path):
         with pytest.raises(TimeoutError, match="timed out after 1s"):
@@ -78,8 +79,9 @@ class TestTaskCliValidation:
         validate_task_cli("tigerflow.library.echo")  # Should not raise
 
     def test_nonexistent_library_module_raises_value_error(self):
-        with pytest.raises(ValueError, match="Invalid task CLI"):
+        with pytest.raises(ValueError, match="Invalid task CLI") as exc_info:
             validate_task_cli("nonexistent.module.path")
+        assert "ModuleNotFoundError" in str(exc_info.value)
 
 
 class TestPidUtilityFunctions:


### PR DESCRIPTION
`is_valid_task_cli` returned `False` on failure, giving the caller no insight into why validation failed. Replace it with `validate_task_cli`, which raises `ValueError` with the captured stderr/stdout, so pipeline errors surface actionable detail rather than an opaque "Invalid task CLI" error.