### PR TITLE
Gracefully tear down Slurm tasks and prevent cross-run job cancellation

### DIFF
--- a/src/tigerflow/models.py
+++ b/src/tigerflow/models.py
@@ -201,6 +201,7 @@ class SlurmTaskConfig(BaseTaskConfig):
     kind: Literal["slurm"]
     max_workers: int
     worker_resources: SlurmResourceConfig
+    runner_pid: int | None = None
 
     @property
     def client_job_time(self) -> str:
@@ -208,11 +209,15 @@ class SlurmTaskConfig(BaseTaskConfig):
 
     @property
     def client_job_name(self) -> str:
-        return f"{self.name}-client"
+        if self.runner_pid is None:
+            return f"{self.name}-client"
+        return f"{self.name}-{self.runner_pid}-client"
 
     @property
     def worker_job_name(self) -> str:
-        return f"{self.name}-worker"
+        if self.runner_pid is None:
+            return f"{self.name}-worker"
+        return f"{self.name}-{self.runner_pid}-worker"
 
     def to_script(self) -> str:
         sbatch_account = next(
@@ -241,6 +246,9 @@ class SlurmTaskConfig(BaseTaskConfig):
                 if self.worker_resources.gpus
                 else "",
                 "--run-directly",
+                f"--runner-pid {self.runner_pid}"
+                if self.runner_pid is not None
+                else "",
             ]
             + [
                 f"--sbatch-option {repr(option)}"

--- a/src/tigerflow/models.py
+++ b/src/tigerflow/models.py
@@ -50,6 +50,7 @@ class BaseTaskConfig(BaseModel):
     setup_commands: list[str] = []
     _input_dir: Path | None = None
     _output_dir: Path | None = None
+    _runner_pid: int | None = None
 
     @field_validator("module")
     @classmethod
@@ -127,8 +128,19 @@ class BaseTaskConfig(BaseModel):
         self._output_dir = value
 
     @property
+    def runner_pid(self) -> int | None:
+        return self._runner_pid
+
+    @runner_pid.setter
+    def runner_pid(self, value: int):
+        self._runner_pid = value
+
+    @property
     def log_dir(self) -> Path:
-        return self.output_dir / "logs"
+        base = self.output_dir / "logs"
+        if self.runner_pid is None:
+            return base
+        return base / str(self.runner_pid)
 
     def to_script(self) -> str:
         """
@@ -141,8 +153,8 @@ class LocalTaskConfig(BaseTaskConfig):
     kind: Literal["local"]
 
     def to_script(self) -> str:
-        stdout_file = self.log_dir / f"{self.name}-$$.out"
-        stderr_file = self.log_dir / f"{self.name}-$$.err"
+        stdout_file = self.log_dir / "task-$$.out"
+        stderr_file = self.log_dir / "task-$$.log"
         setup_command = ";".join(self.setup_commands)
         task_command = " ".join(
             [
@@ -171,8 +183,8 @@ class LocalAsyncTaskConfig(BaseTaskConfig):
     concurrency_limit: int
 
     def to_script(self) -> str:
-        stdout_file = self.log_dir / f"{self.name}-$$.out"
-        stderr_file = self.log_dir / f"{self.name}-$$.err"
+        stdout_file = self.log_dir / "task-$$.out"
+        stderr_file = self.log_dir / "task-$$.log"
         setup_command = ";".join(self.setup_commands)
         task_command = " ".join(
             [
@@ -201,7 +213,6 @@ class SlurmTaskConfig(BaseTaskConfig):
     kind: Literal["slurm"]
     max_workers: int
     worker_resources: SlurmResourceConfig
-    runner_pid: int | None = None
 
     @property
     def client_job_time(self) -> str:
@@ -261,8 +272,8 @@ class SlurmTaskConfig(BaseTaskConfig):
         script = textwrap.dedent(f"""\
             #!/bin/bash
             #SBATCH --job-name={self.client_job_name}
-            #SBATCH --output={self.log_dir}/%x-%j.out
-            #SBATCH --error={self.log_dir}/%x-%j.err
+            #SBATCH --output={self.log_dir}/task-client-%j.out
+            #SBATCH --error={self.log_dir}/task-client-%j.log
             #SBATCH --nodes=1
             #SBATCH --ntasks=1
             #SBATCH --cpus-per-task=1

--- a/src/tigerflow/pipeline.py
+++ b/src/tigerflow/pipeline.py
@@ -200,8 +200,8 @@ class Pipeline:
                 if not isinstance(task, SlurmTaskConfig):
                     continue
                 logger.info("[{}] Terminating...", task.name)
-                subprocess.run(["scancel", "-n", task.client_job_name])
                 subprocess.run(["scancel", "-n", task.worker_job_name])
+                subprocess.run(["scancel", "-n", task.client_job_name])
             while any(status.is_alive for status in self._task_status.values()):
                 self._check_task_status()
                 time.sleep(1)

--- a/src/tigerflow/pipeline.py
+++ b/src/tigerflow/pipeline.py
@@ -214,8 +214,7 @@ class Pipeline:
     def _start_tasks(self):
         for task in self._config.tasks:
             logger.info("[{}] Starting as a {} task", task.name, task.kind.upper())
-            if isinstance(task, SlurmTaskConfig):
-                task.runner_pid = os.getpid()
+            task.runner_pid = os.getpid()
             script = task.to_script()
             if isinstance(task, (LocalTaskConfig, LocalAsyncTaskConfig)):
                 process = subprocess.Popen(["bash", "-c", script])

--- a/src/tigerflow/pipeline.py
+++ b/src/tigerflow/pipeline.py
@@ -196,10 +196,12 @@ class Pipeline:
                 if self._task_status[name].is_alive:
                     logger.info("[{}] Terminating...", name)
                     process.terminate()
-            for name, job_id in self._slurm_task_ids.items():
-                if self._task_status[name].is_alive:
-                    logger.info("[{}] Terminating...", name)
-                    subprocess.run(["scancel", str(job_id)])
+            for task in self._config.tasks:
+                if not isinstance(task, SlurmTaskConfig):
+                    continue
+                logger.info("[{}] Terminating...", task.name)
+                subprocess.run(["scancel", "-n", task.client_job_name])
+                subprocess.run(["scancel", "-n", task.worker_job_name])
             while any(status.is_alive for status in self._task_status.values()):
                 self._check_task_status()
                 time.sleep(1)
@@ -212,6 +214,8 @@ class Pipeline:
     def _start_tasks(self):
         for task in self._config.tasks:
             logger.info("[{}] Starting as a {} task", task.name, task.kind.upper())
+            if isinstance(task, SlurmTaskConfig):
+                task.runner_pid = os.getpid()
             script = task.to_script()
             if isinstance(task, (LocalTaskConfig, LocalAsyncTaskConfig)):
                 process = subprocess.Popen(["bash", "-c", script])

--- a/src/tigerflow/pipeline.py
+++ b/src/tigerflow/pipeline.py
@@ -215,6 +215,7 @@ class Pipeline:
         for task in self._config.tasks:
             logger.info("[{}] Starting as a {} task", task.name, task.kind.upper())
             task.runner_pid = os.getpid()
+            task.log_dir.mkdir(parents=True, exist_ok=True)  # PID-scoped log dir
             script = task.to_script()
             if isinstance(task, (LocalTaskConfig, LocalAsyncTaskConfig)):
                 process = subprocess.Popen(["bash", "-c", script])

--- a/src/tigerflow/tasks/slurm.py
+++ b/src/tigerflow/tasks/slurm.py
@@ -40,6 +40,10 @@ class SlurmTask(Task):
     @logger.catch(reraise=True)
     def __init__(self, config: SlurmTaskConfig):
         self.config = config
+        self._shutdown_event = threading.Event()
+
+    def _signal_handler(self, signum: int, frame: FrameType | None):
+        self._shutdown_event.set()
 
     @logger.catch(reraise=True)
     def start(self, input_dir: Path, output_dir: Path):
@@ -135,32 +139,40 @@ class SlurmTask(Task):
         # Clean up incomplete temporary files left behind by a prior cluster instance
         self._remove_temporary_files(self.config.output_dir)
 
+        # Register signal handlers
+        for sig in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
+            signal.signal(sig, self._signal_handler)
+
         # Monitor for new files and enqueue them for processing
         active_futures: dict[Path, Future] = dict()
-        while True:
-            unprocessed_files = self._get_unprocessed_files(
-                input_dir=self.config.input_dir,
-                input_ext=self.config.input_ext,
-                output_dir=self.config.output_dir,
-                output_ext=self.config.output_ext,
-            )
+        try:
+            while not self._shutdown_event.is_set():
+                unprocessed_files = self._get_unprocessed_files(
+                    input_dir=self.config.input_dir,
+                    input_ext=self.config.input_ext,
+                    output_dir=self.config.output_dir,
+                    output_ext=self.config.output_ext,
+                )
 
-            for file in unprocessed_files:
-                if file not in active_futures:  # Exclude in-progress files
-                    output_fname = (
-                        file.name.removesuffix(self.config.input_ext)
-                        + self.config.output_ext
-                    )
-                    output_file = self.config.output_dir / output_fname
-                    future = client.submit(task, file, output_file)
-                    active_futures[file] = future
+                for file in unprocessed_files:
+                    if file not in active_futures:  # Exclude in-progress files
+                        output_fname = (
+                            file.name.removesuffix(self.config.input_ext)
+                            + self.config.output_ext
+                        )
+                        output_file = self.config.output_dir / output_fname
+                        future = client.submit(task, file, output_file)
+                        active_futures[file] = future
 
-            for key in list(active_futures.keys()):
-                if active_futures[key].done():
-                    active_futures[key].release()
-                    del active_futures[key]
+                for key in list(active_futures.keys()):
+                    if active_futures[key].done():
+                        active_futures[key].release()
+                        del active_futures[key]
 
-            time.sleep(settings.task_poll_interval)
+                self._shutdown_event.wait(timeout=settings.task_poll_interval)
+        finally:
+            client.close()
+            cluster.close()
 
     @classmethod
     def cli(cls):

--- a/src/tigerflow/tasks/slurm.py
+++ b/src/tigerflow/tasks/slurm.py
@@ -116,8 +116,8 @@ class SlurmTask(Task):
             job_extra_directives=self.config.worker_resources.sbatch_options
             + [
                 f"--job-name={self.config.worker_job_name}",
-                f"--output={self.config.log_dir}/%x-%j.out",
-                f"--error={self.config.log_dir}/%x-%j.err",
+                f"--output={self.config.log_dir}/task-worker-%j.out",
+                f"--error={self.config.log_dir}/task-worker-%j.log",
                 f"--gres=gpu:{self.config.worker_resources.gpus}"
                 if self.config.worker_resources.gpus
                 else "",
@@ -305,9 +305,11 @@ class SlurmTask(Task):
                 setup_commands=setup_commands or [],
                 max_workers=max_workers,
                 worker_resources=worker_resources,
-                runner_pid=runner_pid,
                 params=_params or {},
             )
+
+            if runner_pid is not None:
+                config.runner_pid = runner_pid
 
             if run_directly:
                 task = cls(config)

--- a/src/tigerflow/tasks/slurm.py
+++ b/src/tigerflow/tasks/slurm.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 import signal
 import subprocess
 import sys
@@ -274,6 +275,14 @@ class SlurmTask(Task):
                     hidden=True,  # Internal use only
                 ),
             ] = False,
+            runner_pid: Annotated[
+                int | None,
+                typer.Option(
+                    "--runner-pid",
+                    help="PID of the orchestrating process",
+                    hidden=True,  # Internal use only
+                ),
+            ] = None,
             _params: dict | None = None,
         ):
             """
@@ -296,6 +305,7 @@ class SlurmTask(Task):
                 setup_commands=setup_commands or [],
                 max_workers=max_workers,
                 worker_resources=worker_resources,
+                runner_pid=runner_pid,
                 params=_params or {},
             )
 
@@ -387,6 +397,7 @@ class SlurmTaskRunner:
 
         self.config.input_dir = input_dir
         self.config.output_dir = output_dir
+        self.config.runner_pid = os.getpid()
 
         # Register signal handlers for graceful shutdown
         for sig in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
@@ -404,8 +415,8 @@ class SlurmTaskRunner:
                 self._shutdown_event.wait(timeout=settings.task_poll_interval)
         finally:
             logger.info("Shutting down task")
-            if self._status.is_alive:
-                subprocess.run(["scancel", str(self._job_id)])
+            subprocess.run(["scancel", "-n", self.config.client_job_name])
+            subprocess.run(["scancel", "-n", self.config.worker_job_name])
             while self._status.is_alive:
                 self._check_status()
                 time.sleep(1)

--- a/src/tigerflow/tasks/slurm.py
+++ b/src/tigerflow/tasks/slurm.py
@@ -415,8 +415,8 @@ class SlurmTaskRunner:
                 self._shutdown_event.wait(timeout=settings.task_poll_interval)
         finally:
             logger.info("Shutting down task")
-            subprocess.run(["scancel", "-n", self.config.client_job_name])
             subprocess.run(["scancel", "-n", self.config.worker_job_name])
+            subprocess.run(["scancel", "-n", self.config.client_job_name])
             while self._status.is_alive:
                 self._check_status()
                 time.sleep(1)

--- a/src/tigerflow/tasks/slurm.py
+++ b/src/tigerflow/tasks/slurm.py
@@ -59,10 +59,12 @@ class SlurmTask(Task):
         self.config.output_dir = output_dir
         self.config.log_dir.mkdir(exist_ok=True)
 
-        # Reference functions and params to use in plugin
-        setup_func = type(self).setup
-        teardown_func = type(self).teardown
+        # Avoid capturing unpicklable `self` in closures sent to workers
         params = self.config.params
+        output_ext = self.config.output_ext
+        setup_func = type(self).setup
+        run_func = type(self).run
+        teardown_func = type(self).teardown
 
         class TaskWorkerPlugin(WorkerPlugin):
             async def setup(self, worker: Worker):
@@ -93,13 +95,11 @@ class SlurmTask(Task):
             try:
                 logger.info("Starting processing: {}", input_file.name)
                 with atomic_write(output_file) as temp_file:
-                    self.run(context, input_file, temp_file)
+                    run_func(context, input_file, temp_file)
                 logger.info("Successfully processed: {}", input_file.name)
             except Exception:
-                error_fname = (
-                    output_file.name.removesuffix(self.config.output_ext) + ".err"
-                )
-                error_file = self.config.output_dir / error_fname
+                error_fname = output_file.name.removesuffix(output_ext) + ".err"
+                error_file = output_dir / error_fname
                 with atomic_write(error_file) as temp_file:
                     with open(temp_file, "w") as f:
                         f.write(traceback.format_exc())

--- a/src/tigerflow/tasks/utils.py
+++ b/src/tigerflow/tasks/utils.py
@@ -32,7 +32,19 @@ def get_slurm_task_status(client_job_id: int, worker_job_name: str) -> TaskStatu
             kind=TaskStatusKind.PENDING,
             detail=f"Reason: {reason.splitlines()[-1].strip()}" if reason else None,
         )
-    else:
+    else:  # Client exited — check if workers are still draining
+        worker_status = subprocess.run(
+            ["squeue", "--me", "-n", worker_job_name, "-h", "-o", "%.10T"],
+            capture_output=True,
+            text=True,
+        ).stdout
+
+        if worker_status.strip():
+            return TaskStatus(
+                kind=TaskStatusKind.ACTIVE,
+                detail=f"draining {len(worker_status.strip().splitlines())} workers",
+            )
+
         reason = subprocess.run(
             ["sacct", "-j", str(client_job_id), "--format=State", "--noheader"],
             capture_output=True,

--- a/src/tigerflow/utils.py
+++ b/src/tigerflow/utils.py
@@ -112,10 +112,12 @@ def submit_to_slurm(script: str) -> int:
     result = subprocess.run(
         ["sbatch"],
         capture_output=True,
-        check=True,
         input=script,
         text=True,
     )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise RuntimeError(f"sbatch failed (exit code {result.returncode}):\n{detail}")
 
     match = re.search(r"Submitted batch job (\d+)", result.stdout)
     if not match:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -359,8 +359,16 @@ class TestSlurmTaskConfig:
     def test_client_job_name(self, slurm_config: SlurmTaskConfig):
         assert slurm_config.client_job_name == "slurm_task-client"
 
+    def test_client_job_name_with_runner_pid(self, slurm_config: SlurmTaskConfig):
+        slurm_config.runner_pid = 12345
+        assert slurm_config.client_job_name == "slurm_task-12345-client"
+
     def test_worker_job_name(self, slurm_config: SlurmTaskConfig):
         assert slurm_config.worker_job_name == "slurm_task-worker"
+
+    def test_worker_job_name_with_runner_pid(self, slurm_config: SlurmTaskConfig):
+        slurm_config.runner_pid = 12345
+        assert slurm_config.worker_job_name == "slurm_task-12345-worker"
 
     def test_to_script_contains_sbatch_directives(self, slurm_config: SlurmTaskConfig):
         script = slurm_config.to_script()
@@ -483,6 +491,17 @@ class TestSlurmTaskConfig:
             if line.strip().startswith("#SBATCH"):
                 option = line.split("#SBATCH")[1].strip()
                 assert not option.startswith(("--account", "-A"))
+
+    def test_to_script_with_runner_pid(self, slurm_config: SlurmTaskConfig):
+        slurm_config.runner_pid = 12345
+        script = slurm_config.to_script()
+        assert "#SBATCH --job-name=slurm_task-12345-client" in script
+        assert "--runner-pid 12345" in script
+
+    def test_to_script_without_runner_pid(self, slurm_config: SlurmTaskConfig):
+        script = slurm_config.to_script()
+        assert "#SBATCH --job-name=slurm_task-client" in script
+        assert "--runner-pid" not in script
 
 
 class TestPipelineConfig:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -129,11 +129,22 @@ class TestBaseTaskConfig:
         config.output_dir = output_dir
         assert config.output_dir == output_dir
 
-    def test_log_dir_property(self, tmp_module: str, tmp_dirs: tuple[Path, Path]):
+    def test_log_dir_without_runner_pid(
+        self, tmp_module: str, tmp_dirs: tuple[Path, Path]
+    ):
         _, output_dir = tmp_dirs
         config = BaseTaskConfig(name="test", module=tmp_module, input_ext=".txt")
         config.output_dir = output_dir
         assert config.log_dir == output_dir / "logs"
+
+    def test_log_dir_with_runner_pid(
+        self, tmp_module: str, tmp_dirs: tuple[Path, Path]
+    ):
+        _, output_dir = tmp_dirs
+        config = BaseTaskConfig(name="test", module=tmp_module, input_ext=".txt")
+        config.output_dir = output_dir
+        config.runner_pid = 48201
+        assert config.log_dir == output_dir / "logs" / "48201"
 
     def test_default_output_ext(self, tmp_module: str):
         config = BaseTaskConfig(name="test", module=tmp_module, input_ext=".txt")
@@ -491,6 +502,13 @@ class TestSlurmTaskConfig:
             if line.strip().startswith("#SBATCH"):
                 option = line.split("#SBATCH")[1].strip()
                 assert not option.startswith(("--account", "-A"))
+
+    def test_to_script_log_file_directives(self, slurm_config: SlurmTaskConfig):
+        slurm_config.runner_pid = 12345
+        script = slurm_config.to_script()
+        log_dir = slurm_config.log_dir
+        assert f"#SBATCH --output={log_dir}/task-client-%j.out" in script
+        assert f"#SBATCH --error={log_dir}/task-client-%j.log" in script
 
     def test_to_script_with_runner_pid(self, slurm_config: SlurmTaskConfig):
         slurm_config.runner_pid = 12345


### PR DESCRIPTION
## Summary

- Gracefully shut down Slurm tasks when the pipeline receives termination signals, preventing orphaned worker
 jobs
- Report ACTIVE status for Slurm tasks while workers are still draining — to prevent premature task completion
- Scope Slurm job names to the runner PID (e.g., `task-12345-worker`) so `scancel` only targets jobs from the current pipeline run, avoiding collisions when multiple runs share a task name
- Scope log directories by runner PID for all task types to isolate logs across runs:
  ```
  <output_dir>/logs/<runner_pid>/
    task-client-<job_id>.{out,log}   # slurm client
    task-worker-<job_id>.{out,log}   # slurm workers
    task-<pid>.{out,log}             # local / local-async
  ```


## Testing

- [x] Verify a single pipeline run tears down cleanly on `Ctrl+C` with no orphaned Slurm jobs
- [x] Run two pipelines concurrently with overlapping task names and confirm terminating one does not cancel
the other's jobs