### PR TITLE
Abort `SlurmTask` on worker setup failure to prevent infinite resubmission

### DIFF
--- a/src/tigerflow/tasks/slurm.py
+++ b/src/tigerflow/tasks/slurm.py
@@ -58,6 +58,7 @@ class SlurmTask(Task):
         self.config.output_dir = output_dir
 
         # Avoid capturing unpicklable `self` in closures sent to workers
+        setup_failed_sentinel = self.config.log_dir / ".setup-failed"
         params = self.config.params
         output_ext = self.config.output_ext
         setup_func = type(self).setup
@@ -67,25 +68,31 @@ class SlurmTask(Task):
         class TaskWorkerPlugin(WorkerPlugin):
             async def setup(self, worker: Worker):
                 logger.info("Setting up task")
-                context = SetupContext()
-
-                # Inject params into context
-                for key, value in params.items():
-                    setattr(context, key, value)
-
-                loop = asyncio.get_running_loop()
-                await loop.run_in_executor(None, setup_func, context)
-                context.freeze()  # Make it read-only
-
-                setattr(worker, "context", context)
-                logger.info("Task setup complete")
+                try:
+                    context = SetupContext()
+                    for key, value in params.items():
+                        setattr(context, key, value)
+                    loop = asyncio.get_running_loop()
+                    await loop.run_in_executor(None, setup_func, context)
+                    context.freeze()  # Make it read-only
+                    setattr(worker, "context", context)
+                    logger.info("Task setup complete")
+                except Exception:
+                    logger.exception("Task setup failed; aborting task")
+                    setup_failed_sentinel.touch()
 
             async def teardown(self, worker: Worker):
-                logger.info("Shutting down task")
-                context = getattr(worker, "context")
-                loop = asyncio.get_running_loop()
-                await loop.run_in_executor(None, teardown_func, context)
-                logger.info("Task shutdown complete")
+                logger.info("Tearing down task")
+                context = getattr(worker, "context", None)
+                if context is None:
+                    logger.warning("Skipping teardown: task setup failed")
+                    return
+                try:
+                    loop = asyncio.get_running_loop()
+                    await loop.run_in_executor(None, teardown_func, context)
+                    logger.info("Task teardown complete")
+                except Exception:
+                    logger.exception("Task teardown failed")
 
         def task(input_file: Path, output_file: Path):
             with log_metrics(input_file.name) as metrics:
@@ -131,12 +138,13 @@ class SlurmTask(Task):
             wait_count=settings.slurm_task_scale_wait_count,
         )
 
+        # Clean up stale state from any prior cluster instance
+        self._remove_temporary_files(self.config.output_dir)
+        setup_failed_sentinel.unlink(missing_ok=True)
+
         # Instantiate a cluster client
         client = Client(cluster)
         client.register_plugin(TaskWorkerPlugin())
-
-        # Clean up incomplete temporary files left behind by a prior cluster instance
-        self._remove_temporary_files(self.config.output_dir)
 
         # Register signal handlers
         for sig in (signal.SIGINT, signal.SIGTERM, signal.SIGHUP):
@@ -146,6 +154,9 @@ class SlurmTask(Task):
         active_futures: dict[Path, Future] = dict()
         try:
             while not self._shutdown_event.is_set():
+                if setup_failed_sentinel.exists():
+                    raise RuntimeError("Task setup failed on a worker")
+
                 unprocessed_files = self._get_unprocessed_files(
                     input_dir=self.config.input_dir,
                     input_ext=self.config.input_ext,
@@ -164,8 +175,15 @@ class SlurmTask(Task):
                         active_futures[file] = future
 
                 for key in list(active_futures.keys()):
-                    if active_futures[key].done():
-                        active_futures[key].release()
+                    future = active_futures[key]
+                    if future.done():
+                        if future.status == "error":
+                            logger.error(
+                                "Task future errored for {}: {}",
+                                key.name,
+                                future.exception(),
+                            )
+                        future.release()
                         del active_futures[key]
 
                 self._shutdown_event.wait(timeout=settings.task_poll_interval)

--- a/src/tigerflow/tasks/slurm.py
+++ b/src/tigerflow/tasks/slurm.py
@@ -95,9 +95,11 @@ class SlurmTask(Task):
                     logger.exception("Task teardown failed")
 
         def task(input_file: Path, output_file: Path):
+            worker = get_worker()
+            context = getattr(worker, "context", None)
+            if context is None:
+                raise RuntimeError("Skipping file processing: task setup failed")
             with log_metrics(input_file.name) as metrics:
-                worker = get_worker()
-                context = getattr(worker, "context")
                 try:
                     logger.info("Starting processing: {}", input_file.name)
                     with atomic_write(output_file) as temp_file:
@@ -174,8 +176,7 @@ class SlurmTask(Task):
                         future = client.submit(task, file, output_file)
                         active_futures[file] = future
 
-                for key in list(active_futures.keys()):
-                    future = active_futures[key]
+                for key, future in list(active_futures.items()):
                     if future.done():
                         if future.status == "error":
                             logger.error(

--- a/tests/integration/test_slurm_task.py
+++ b/tests/integration/test_slurm_task.py
@@ -40,20 +40,15 @@ skip_if_no_test_dir = pytest.mark.skipif(
 pytestmark = [skip_if_disabled, skip_if_no_sbatch, skip_if_no_test_dir]
 
 
-def run_slurm_task_until_complete(
+def _build_slurm_task_cmd(
     script: Path,
     input_dir: Path,
     output_dir: Path,
     input_ext: str,
     output_ext: str,
-    expected_count: int,
     extra_args: list[str] | None = None,
-    timeout: float = 180,
-):
-    """Run Slurm task via subprocess and wait for output files.
-
-    Uses SlurmTaskRunner (default mode) which submits to Slurm.
-    """
+) -> list[str]:
+    """Build the command to run a Slurm task via subprocess."""
     # Create logs directory
     log_dir = output_dir / "logs"
     log_dir.mkdir(exist_ok=True)
@@ -81,6 +76,26 @@ def run_slurm_task_until_complete(
     if extra_args:
         cmd.extend(extra_args)
 
+    return cmd
+
+
+def run_slurm_task_until_complete(
+    script: Path,
+    input_dir: Path,
+    output_dir: Path,
+    input_ext: str,
+    output_ext: str,
+    expected_count: int,
+    extra_args: list[str] | None = None,
+    timeout: float = 180,
+):
+    """Run Slurm task via subprocess and wait for output files.
+
+    Uses SlurmTaskRunner (default mode) which submits to Slurm.
+    """
+    cmd = _build_slurm_task_cmd(
+        script, input_dir, output_dir, input_ext, output_ext, extra_args
+    )
     proc = subprocess.Popen(cmd)
 
     try:
@@ -106,6 +121,35 @@ def run_slurm_task_until_complete(
     finally:
         proc.send_signal(signal.SIGTERM)
         proc.wait(timeout=30)
+
+
+def run_slurm_task_until_exit(
+    script: Path,
+    input_dir: Path,
+    output_dir: Path,
+    input_ext: str,
+    output_ext: str,
+    extra_args: list[str] | None = None,
+    timeout: float = 180,
+) -> subprocess.Popen:
+    """Run Slurm task via subprocess and wait for it to exit.
+
+    Unlike run_slurm_task_until_complete, this waits for the process
+    to terminate on its own (e.g., due to a fatal error) rather than
+    waiting for output files.
+    """
+    cmd = _build_slurm_task_cmd(
+        script, input_dir, output_dir, input_ext, output_ext, extra_args
+    )
+    proc = subprocess.Popen(cmd)
+
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.send_signal(signal.SIGTERM)
+        proc.wait(timeout=30)
+
+    return proc
 
 
 @pytest.fixture
@@ -206,3 +250,32 @@ class TestSlurmTaskIntegration:
         err_file = output_dir / "fail.err"
         assert err_file.exists()
         assert "Intentional Slurm failure" in err_file.read_text()
+
+    def test_setup_failure_aborts(self, task_dirs, input_files, tasks_dir):
+        """Test that setup failure writes sentinel and aborts the task."""
+        input_dir, output_dir = task_dirs
+
+        proc = run_slurm_task_until_exit(
+            script=tasks_dir / "slurm_failing_setup.py",
+            input_dir=input_dir,
+            output_dir=output_dir,
+            input_ext=".txt",
+            output_ext=".out",
+        )
+
+        assert proc.returncode != 0
+
+        # Sentinel should exist under the runner's log directory
+        log_base = output_dir / "logs"
+        sentinel_files = list(log_base.rglob(".setup-failed"))
+        assert len(sentinel_files) > 0, "Expected .setup-failed sentinel file"
+
+        # No output files should have been produced
+        output_files = [
+            f
+            for f in output_dir.iterdir()
+            if f.is_file()
+            and f.suffix == ".out"
+            and not f.name.startswith(TEMP_FILE_PREFIX)
+        ]
+        assert len(output_files) == 0

--- a/tests/tasks/slurm_failing_setup.py
+++ b/tests/tasks/slurm_failing_setup.py
@@ -1,0 +1,20 @@
+"""A Slurm task whose setup always fails - for testing abort-on-setup-failure."""
+
+from pathlib import Path
+
+from tigerflow.tasks import SlurmTask
+from tigerflow.utils import SetupContext
+
+
+class SlurmFailingSetupTask(SlurmTask):
+    @staticmethod
+    def setup(context: SetupContext):
+        raise RuntimeError("Intentional setup failure")
+
+    @staticmethod
+    def run(context: SetupContext, input_file: Path, output_file: Path):
+        raise AssertionError("run() should never be reached")
+
+
+if __name__ == "__main__":
+    SlurmFailingSetupTask.cli()


### PR DESCRIPTION
## Summary

When `TaskWorkerPlugin.setup()` raises, workers remain alive without a valid `context`, causing all submitted tasks to fail and be resubmitted indefinitely. This change introduces a sentinel file in `log_dir` that is written on setup failure; the client loop detects it on the next poll and raises a `RuntimeError`, aborting the run.

- Catch exceptions in `setup()` and write a failure sentinel
- Client loop checks sentinel and aborts early
- Skip `teardown` gracefully when setup never completed
- Log errored futures with exception details for visibility
- Clear sentinel before client start to avoid stale state

## Testing

- [x] Unit tests (238 passed)
- [x] Integration tests (including Slurm ones)
- [x] Manual test of a Slurm-task pipeline