### PR TITLE
Support tasks with optional param(s)

### DIFF
--- a/src/tigerflow/models.py
+++ b/src/tigerflow/models.py
@@ -129,6 +129,8 @@ class BaseTaskConfig(BaseModel):
         """Convert params dict to CLI argument strings."""
         args = []
         for key, value in self.params.items():
+            if value is None:
+                continue
             # Convert underscores to hyphens for CLI convention
             cli_key = key.replace("_", "-")
             if isinstance(value, bool):

--- a/src/tigerflow/models.py
+++ b/src/tigerflow/models.py
@@ -111,14 +111,12 @@ class BaseTaskConfig(BaseModel):
 
     @staticmethod
     def _serialize_param(value: object) -> str:
-        """Serialize a parameter value to a shell-safe CLI string.
+        """Serialize a single scalar param value to a shell-safe CLI string.
 
-        Param values are limited to Typer-supported types (str, int, float,
-        Path, UUID, datetime, Enum) because Typer rejects unsupported type
-        annotations at runtime. str() produces the format Typer expects when
-        it re-parses the CLI string back into the correct Python type. Enum
-        is the exception: Typer expects the .value string, not the member
-        name that str() would produce.
+        `str()` produces the format Typer expects when it re-parses the CLI
+        string back into the correct Python type. `Enum` is the exception:
+        Typer expects the `.value` string, not the member name that `str()`
+        would produce.
         """
         if isinstance(value, Enum):
             return shlex.quote(str(value.value))
@@ -126,7 +124,20 @@ class BaseTaskConfig(BaseModel):
 
     @property
     def params_as_cli_args(self) -> list[str]:
-        """Convert params dict to CLI argument strings."""
+        """Convert params dict to CLI argument strings.
+
+        Param values originate from Typer-parsed CLI options declared on a
+        task's `Params` class, so their runtime types are restricted to
+        Typer-supported types: `str`, `int`, `float`, `bool`, `Path`,
+        `UUID`, `datetime`, `Enum`, `list[...]` of those, or `None` (from
+        `Optional[...]`).
+
+        `None` values are skipped. Bools become presence flags (`--flag`
+        when `True`, omitted when `False`). Lists are expanded into one
+        `--key=item` argument per element, with each item serialized via
+        `_serialize_param`. Any other value is serialized via
+        `_serialize_param` directly.
+        """
         args = []
         for key, value in self.params.items():
             if value is None:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -327,19 +327,7 @@ class TestBaseTaskConfig:
         assert "--extra-dirs=/data/a" in args
         assert "--extra-dirs=/data/b" in args
 
-    def test_params_as_cli_args_none_value_omitted(self):
-        """None params must be skipped entirely — not serialized as the string 'None'."""
-        config = BaseTaskConfig(
-            name="test",
-            module="tigerflow.library.echo",
-            params={"none-param": None},
-            input_ext=".txt",
-        )
-        args = config.params_as_cli_args
-        assert args == []
-        assert "--none-param=None" not in args
-
-    def test_params_as_cli_args_none_mixed_with_non_none(self):
+    def test_params_as_cli_args_none_values_omitted(self):
         """None params are skipped while non-None params are still emitted."""
         config = BaseTaskConfig(
             name="test",
@@ -347,10 +335,7 @@ class TestBaseTaskConfig:
             params={"none-param": None, "actual-value-param": "valid string"},
             input_ext=".txt",
         )
-        args = config.params_as_cli_args
-        assert "--none-param=None" not in args
-        assert any("none-param" in arg for arg in args) is False
-        assert "--actual-value-param='valid string'" in args
+        assert config.params_as_cli_args == ["--actual-value-param='valid string'"]
 
 
 class TestLocalTaskConfig:

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -327,6 +327,31 @@ class TestBaseTaskConfig:
         assert "--extra-dirs=/data/a" in args
         assert "--extra-dirs=/data/b" in args
 
+    def test_params_as_cli_args_none_value_omitted(self):
+        """None params must be skipped entirely — not serialized as the string 'None'."""
+        config = BaseTaskConfig(
+            name="test",
+            module="tigerflow.library.echo",
+            params={"none-param": None},
+            input_ext=".txt",
+        )
+        args = config.params_as_cli_args
+        assert args == []
+        assert "--none-param=None" not in args
+
+    def test_params_as_cli_args_none_mixed_with_non_none(self):
+        """None params are skipped while non-None params are still emitted."""
+        config = BaseTaskConfig(
+            name="test",
+            module="tigerflow.library.echo",
+            params={"none-param": None, "actual-value-param": "valid string"},
+            input_ext=".txt",
+        )
+        args = config.params_as_cli_args
+        assert "--none-param=None" not in args
+        assert any("none-param" in arg for arg in args) is False
+        assert "--actual-value-param='valid string'" in args
+
 
 class TestLocalTaskConfig:
     def test_to_script(self, tmp_module: str, tmp_dirs: tuple[Path, Path]):


### PR DESCRIPTION
When using `tigerflow` to run a task with parameter defaults of `None`, I encountered the error: `njinja2.exceptions.UndefinedError: 'dict object' has no attribute 'None'\n"`.  

**The [translation] task setup:**

```python
class Params(HFParams):
        model: Annotated[
            str,
            typer.Option(help="HuggingFace model repo ID"),
        ] = "google/translategemma-12b-it"

        source_lang: Annotated[
            str | None,
            typer.Option(help="Source language code (e.g. 'en', 'de', 'zh')"),
        ] = None

        target_lang: Annotated[
            str,
            typer.Option(help="Target language code (e.g. 'de', 'en', 'fr')"),
        ] = "en"

        chunk_size: Annotated[
            int,
            typer.Option(help="Maximum tokens per chunk"),
        ] = MAX_CHUNK_TOKENS

        batch_size: Annotated[
            int | None, 
            typer.Option(help="Chunks to translate in parallel (default: auto)"),
        ] = None
        
        fetch: Annotated[
            bool,
            typer.Option(help="Allow downloading from HuggingFace Hub"),
        ] = False
```

**An example TigerFlow .err output:**

```
{
  "file": "french.txt",
  "timestamp": "2026-04-10T18:14:00.552270+00:00",
  "exception_type": "UndefinedError",
  "message": "'dict object' has no attribute 'None'",
  "traceback": "Traceback (most recent call last):\n  File \"/scratch/gpfs/TITIUNIK/nv5842/github/tigerflow-ml/.venv/lib/python3.10/site-packages/tigerflow/tasks/slurm.py\", line 97, in task\n    run_func(context, input_file, temp_file)\n  File \"/scratch/gpfs/TITIUNIK/nv5842/github/tigerflow-ml/src/tigerflow_ml/text/translate2/_base.py\", line 95, in run\n    _translate_file(context.translator, input_file, output_file, context.source_lang, context.target_lang, logger.info)\n  File \"/scratch/gpfs/TITIUNIK/nv5842/github/tigerflow-ml/src/tigerflow_ml/text/translate2/_base.py\", line 199, in _translate_file\n    translated = _translate_text(content, translator, detected_lang, target_lang)\n  File \"/scratch/gpfs/TITIUNIK/nv5842/github/tigerflow-ml/src/tigerflow_ml/text/translate2/_base.py\", line 248, in _translate_text\n    return \"\\n\\n\".join(translator.translate_batch(chunks, source_lang, target_lang))\n  File \"/scratch/gpfs/TITIUNIK/nv5842/github/tigerflow-ml/src/tigerflow_ml/text/translate2/translator.py\", line 145, in translate_batch\n    outputs = self.pipe(\n  File \"/scratch/gpfs/TITIUNIK/nv5842/github/tigerflow-ml/.venv/lib/python3.10/site-packages/transformers/pipelines/image_text_to_text.py\", line 286, in __call__\n    return super().__call__(chats, **kwargs)\n  File \"/scratch/gpfs/TITIUNIK/nv5842/github/tigerflow-ml/.venv/lib/python3.10/site-packages/transformers/pipelines/base.py\", line 1255, in __call__\n    outputs = list(final_iterator)\n  File \"/scratch/gpfs/TITIUNIK/nv5842/github/tigerflow-ml/.venv/lib/python3.10/site-packages/transformers/pipelines/pt_utils.py\", line 126, in __next__\n    item = next(self.iterator)\n  File \"/scratch/gpfs/TITIUNIK/nv5842/github/tigerflow-ml/.venv/lib/python3.10/site-packages/transformers/pipelines/pt_utils.py\", line 126, in __next__\n    item = next(self.iterator)\n  File \"/scratch/gpfs/TITIUNIK/nv5842/github/tigerflow-ml/.venv/lib/python3.10/site-packages/torch/utils/data/dataloader.py\", line 741, in __next__\n    data = self._next_data()\n  File \"/scratch/gpfs/TITIUNIK/nv5842/github/tigerflow-ml/.venv/lib/python3.10/site-packages/torch/utils/data/dataloader.py\", line 801, in _next_data\n    data = self._dataset_fetcher.fetch(index)  # may raise StopIteration\n  File \"/scratch/gpfs/TITIUNIK/nv5842/github/tigerflow-ml/.venv/lib/python3.10/site-packages/torch/utils/data/_utils/fetch.py\", line 54, in fetch\n    data = [self.dataset[idx] for idx in possibly_batched_index]\n  File \"/scratch/gpfs/TITIUNIK/nv5842/github/tigerflow-ml/.venv/lib/python3.10/site-packages/torch/utils/data/_utils/fetch.py\", line 54, in <listcomp>\n    data = [self.dataset[idx] for idx in possibly_batched_index]\n  File \"/scratch/gpfs/TITIUNIK/nv5842/github/tigerflow-ml/.venv/lib/python3.10/site-packages/transformers/pipelines/pt_utils.py\", line 19, in __getitem__\n    processed = self.process(item, **self.params)\n  File \"/scratch/gpfs/TITIUNIK/nv5842/github/tigerflow-ml/.venv/lib/python3.10/site-packages/transformers/pipelines/image_text_to_text.py\", line 330, in preprocess\n    model_inputs = self.processor.apply_chat_template(\n  File \"/scratch/gpfs/TITIUNIK/nv5842/github/tigerflow-ml/.venv/lib/python3.10/site-packages/transformers/processing_utils.py\", line 1781, in apply_chat_template\n    prompt, generation_indices = render_jinja_template(\n  File \"/scratch/gpfs/TITIUNIK/nv5842/github/tigerflow-ml/.venv/lib/python3.10/site-packages/transformers/utils/chat_template_utils.py\", line 537, in render_jinja_template\n    rendered_chat = compiled_template.render(\n  File \"/scratch/gpfs/TITIUNIK/nv5842/github/tigerflow-ml/.venv/lib/python3.10/site-packages/jinja2/environment.py\", line 1295, in render\n    self.environment.handle_exception()\n  File \"/scratch/gpfs/TITIUNIK/nv5842/github/tigerflow-ml/.venv/lib/python3.10/site-packages/jinja2/environment.py\", line 942, in handle_exception\n    raise rewrite_traceback_stack(source=source)\n  File \"<template>\", line 614, in top-level template code\njinja2.exceptions.UndefinedError: 'dict object' has no attribute 'None'\n"
}
```

This error appears to be rooted in the `params_as_cli_args()` method in Tigerflow's `models.py`. Here, `None` gets converted to the string `"None"`, resulting in the worker receiving `source_lang="None"`. In the translation task, this causes the `if detected_lang is None` check to pass silently and the resulting error.

### The fix

In `params_as_cli_args()`, `None` values should be skipped so they won't be serialized to `"None"`. 

Additional tests added ensure that `None` parameters are skipped while non-none parameters are processed normally. 