### PR TITLE
Clean up outdated code and docs missed in previous PRs

### DIFF
--- a/docs/mkdocs/guides/pipeline.md
+++ b/docs/mkdocs/guides/pipeline.md
@@ -371,29 +371,29 @@ and errors:
 === "Output"
 
     ```
-    ╭─ tigerflow report ─────────────────────────────────────────────────────────────────────────────────────────╮
-    │                                                                                                            │
-    │ Status:  ● running (pid 45760)                                                                             │
-    │ Output:  /private/var/folders/_k/1p72bgt14pxf0918h43wfht00000gn/T/tigerflow-test-kre0xlge/output           │
-    │                                                                                                            │
-    │ Progress: ○ 83 staged → ◐ 1 in progress → ✓ 13 processed, ✗ 3 failed                                       │
-    │                                                                                                            │
-    │   transcribe  ━━━━━━────────────────────────────────── 16 / 100, 1 failed                                  │
-    │   embed       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━─── 13 / 16, 2 failed                                   │
-    │   ingest      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 13 / 13                                             │
-    │                                                                                                            │
-    │ Metrics:                                                                                                   │
-    │                                                                                                            │
-    │   transcribe      ▇▃▃▄▃▃▂▁▃▃▁▂▂▁▄▃  2.0s – 2.0s (2.0s avg)                                                 │
-    │   embed              █▂▁▃▁▂▂▁▂▁▃▁▃  501ms – 501ms (501ms avg)                                              │
-    │   ingest             █▄▂▅▁▄▃▁▇▄▄▁▄  100ms – 101ms (101ms avg)                                              │
-    │                                                                                                            │
-    │ Errors: 3                                                                                                  │
-    │   transcribe  0016.mp4  ClientResponseError: 400, ...                                                      │
-    │   transcribe  0004.mp4  ClientResponseError: 400, ...                                                      │
-    │   transcribe  0028.mp4  ClientResponseError: 400, ...                                                      │
-    │                                                                                                            │
-    ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+    ╭─ tigerflow report ──────────────────────────────────────────────────────────────────────────╮
+    │                                                                                             │
+    │ Status:  ● running (pid 45760)                                                              │
+    │ Output:  path/to/results/                                                                   │
+    │                                                                                             │
+    │ Progress: ○ 83 staged → ◐ 1 in progress → ✓ 13 processed, ✗ 3 failed                        │
+    │                                                                                             │
+    │   transcribe  ━━━━━━────────────────────────────────── 16 / 100, 1 failed                   │
+    │   embed       ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━─── 13 / 16, 2 failed                    │
+    │   ingest      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 13 / 13                              │
+    │                                                                                             │
+    │ Metrics:                                                                                    │
+    │                                                                                             │
+    │   transcribe      ▄▂▆▃█▅▂▁▃▇▄▂▅▃▆▁  1.2s – 3.8s (2.1s avg)                                  │
+    │   embed              █▃▁▅▂▇▄▂▆▁▃▅▂  318ms – 812ms (497ms avg)                               │
+    │   ingest             ▂█▄▁▅▃▇▂▄▆▁▃▅  42ms – 187ms (96ms avg)                                 │
+    │                                                                                             │
+    │ Errors: 3                                                                                   │
+    │   transcribe  0016.mp4  RuntimeError: Failed to load audio: ffmpeg error (see stderr ...    │
+    │   embed  0004.txt  RateLimitError: 429 Too Many Requests                                    │
+    │   embed  0028.txt  RateLimitError: 429 Too Many Requests                                    │
+    │                                                                                             │
+    ╰─────────────────────────────────────────────────────────────────────────────────────────────╯
     ```
 
     The actual terminal output is colorized (green for processed, yellow for in progress,

--- a/examples/audio_feature_extraction/README.md
+++ b/examples/audio_feature_extraction/README.md
@@ -14,7 +14,7 @@ it should be run on a login/head node of a Slurm-managed HPC cluster.
 - [ ] Install the package with the additional dependencies required to run the examples:
 
     ```bash
-    pip install tigerflow aiohttp duckdb openai-whisper
+    pip install tigerflow aiofiles aiohttp duckdb openai-whisper
     ```
 
 - [ ] Update `setup_commands` in `code/config.yaml` to correctly activate the virtual environment where TigerFlow is installed.

--- a/examples/simple_pipeline_local/README.md
+++ b/examples/simple_pipeline_local/README.md
@@ -14,7 +14,7 @@ including a personal laptop.
 - [ ] Install the package with the additional dependencies required to run the examples:
 
     ```bash
-    pip install tigerflow aiohttp
+    pip install tigerflow aiofiles aiohttp
     ```
 
 ## Running the Pipeline

--- a/examples/simple_pipeline_slurm/README.md
+++ b/examples/simple_pipeline_slurm/README.md
@@ -14,7 +14,7 @@ it should be run on a login/head node of a Slurm-managed HPC cluster.
 - [ ] Install the package with the additional dependencies required to run the examples:
 
     ```bash
-    pip install tigerflow aiohttp
+    pip install tigerflow aiofiles aiohttp
     ```
 
 - [ ] Update `setup_commands` in `code/config.yaml` to correctly activate the virtual environment where TigerFlow is installed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "aiofiles>=24.1.0",
     "dask-jobqueue>=0.9.0",
     "loguru>=0.7.3",
     "networkx>=3.4.2",
@@ -47,6 +46,7 @@ docs = [
     "mkdocs-material>=9.7.0",
 ]
 test = [
+    "aiofiles>=25.1.0",
     "pytest>=9.0.2",
 ]
 

--- a/src/tigerflow/models.py
+++ b/src/tigerflow/models.py
@@ -12,7 +12,12 @@ from pydantic import BaseModel, Field, field_validator
 
 from tigerflow.settings import settings
 from tigerflow.staging import StagingPipeline
-from tigerflow.utils import is_process_running, read_pid_file, validate_file_ext
+from tigerflow.utils import (
+    TEMP_FILE_PREFIX,
+    is_process_running,
+    read_pid_file,
+    validate_file_ext,
+)
 
 
 class TaskStatusKind(Enum):
@@ -609,7 +614,11 @@ class PipelineOutput:
         for task_dir in self._get_task_dirs():
             task_errors: list[FileError] = []
             for file in task_dir.iterdir():
-                if file.is_file() and file.name.endswith(".err"):
+                if (
+                    file.is_file()
+                    and file.name.endswith(".err")
+                    and not file.name.startswith(TEMP_FILE_PREFIX)
+                ):
                     stem = file.name.removesuffix(".err")
                     failed_stems.add(stem)
                     try:
@@ -648,8 +657,7 @@ class PipelineOutput:
                 if (
                     file.is_file()
                     and not file.name.endswith(".err")
-                    and not file.name.endswith(".log")
-                    and not file.name.startswith("task-")
+                    and not file.name.startswith(TEMP_FILE_PREFIX)
                 ):
                     stems_with_output.add(file.stem)
 

--- a/tests/manual/README.md
+++ b/tests/manual/README.md
@@ -6,23 +6,23 @@ Scripts for manually testing long-running pipelines.
 
 ```bash
 # Local task (sequential processing)
-python tests/user/run_pipeline.py --kind local --num-files 10 --delay 2.0
+python tests/manual/run_pipeline.py --kind local --num-files 10 --delay 2.0
 
 # Local async task (concurrent processing)
-python tests/user/run_pipeline.py --kind local_async --num-files 20 --delay 1.0 --concurrency-limit 4
+python tests/manual/run_pipeline.py --kind local_async --num-files 20 --delay 1.0 --concurrency-limit 4
 
 # Slurm task (distributed processing, use uv run on the cluster)
 # Use --tmp-dir to place files on a shared filesystem accessible to compute nodes
-uv run python tests/user/run_pipeline.py --kind slurm --num-files 50 --delay 5.0 --max-workers 4 --tmp-dir /scratch/$USER
+uv run python tests/manual/run_pipeline.py --kind slurm --num-files 50 --delay 5.0 --max-workers 4 --tmp-dir /scratch/$USER
 
 # With random failures (10% failure rate)
-python tests/user/run_pipeline.py --kind local --num-files 20 --fail-rate 0.1
+python tests/manual/run_pipeline.py --kind local --num-files 20 --fail-rate 0.1
 
 # With delay variation (±30% random variation in processing time)
-python tests/user/run_pipeline.py --kind local --num-files 10 --delay 2.0 --delay-variation 0.3
+python tests/manual/run_pipeline.py --kind local --num-files 10 --delay 2.0 --delay-variation 0.3
 
 # Multi-task pipeline (comma-separated values)
-python tests/user/run_pipeline.py --kind local,local_async --delay 1.0,2.0 --fail-rate 0.1,0.2
+python tests/manual/run_pipeline.py --kind local,local_async --delay 1.0,2.0 --fail-rate 0.1,0.2
 ```
 
 ## Options

--- a/tests/manual/run_pipeline.py
+++ b/tests/manual/run_pipeline.py
@@ -4,13 +4,13 @@ Creates a temporary pipeline with configurable task kind, input files,
 and runs it in background mode for manual testing.
 
 Usage:
-    python tests/user/run_pipeline.py --kind local --num-files 10 --delay 2.0
-    python tests/user/run_pipeline.py --kind local_async --num-files 20 --fail-rate 0.1
-    python tests/user/run_pipeline.py --kind slurm --num-files 50 --delay 5.0
+    python tests/manual/run_pipeline.py --kind local --num-files 10 --delay 2.0
+    python tests/manual/run_pipeline.py --kind local_async --num-files 20 --fail-rate 0.1
+    python tests/manual/run_pipeline.py --kind slurm --num-files 50 --delay 5.0
 
 Multi-task pipelines (comma-separated values):
-    python tests/user/run_pipeline.py --kind local,local --delay 1.0,2.0
-    python tests/user/run_pipeline.py --kind local,local_async --delay 1.0 --fail-rate 0.1,0.2
+    python tests/manual/run_pipeline.py --kind local,local --delay 1.0,2.0
+    python tests/manual/run_pipeline.py --kind local,local_async --delay 1.0 --fail-rate 0.1,0.2
 """
 
 import re

--- a/uv.lock
+++ b/uv.lock
@@ -8,11 +8,11 @@ resolution-markers = [
 
 [[package]]
 name = "aiofiles"
-version = "24.1.0"
+version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0b/03/a88171e277e8caa88a4c77808c20ebb04ba74cc4681bf1e9416c862de237/aiofiles-24.1.0.tar.gz", hash = "sha256:22a075c9e5a3810f0c2e48f3008c94d68c65d763b9b03857924c99e57355166c", size = 30247, upload-time = "2024-06-24T11:02:03.584Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/45/30bb92d442636f570cb5651bc661f52b610e2eec3f891a5dc3a4c3667db0/aiofiles-24.1.0-py3-none-any.whl", hash = "sha256:b4ec55f4195e3eb5d7abd1bf7e061763e864dd4954231fb8539a0ef8bb8260e5", size = 15896, upload-time = "2024-06-24T11:02:01.529Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
 ]
 
 [[package]]
@@ -1005,7 +1005,6 @@ name = "tigerflow"
 version = "0.3.0"
 source = { editable = "." }
 dependencies = [
-    { name = "aiofiles" },
     { name = "dask-jobqueue" },
     { name = "loguru" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1018,6 +1017,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "aiofiles" },
     { name = "mike" },
     { name = "mkdocs-material" },
     { name = "pre-commit" },
@@ -1033,12 +1033,12 @@ lint = [
     { name = "ty" },
 ]
 test = [
+    { name = "aiofiles" },
     { name = "pytest" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "dask-jobqueue", specifier = ">=0.9.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "networkx", specifier = ">=3.4.2" },
@@ -1050,6 +1050,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "aiofiles", specifier = ">=25.1.0" },
     { name = "mike", specifier = ">=2.1.3" },
     { name = "mkdocs-material", specifier = ">=9.7.0" },
     { name = "pre-commit", specifier = ">=4.0.0" },
@@ -1064,7 +1065,10 @@ lint = [
     { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "ty", specifier = ">=0.0.17" },
 ]
-test = [{ name = "pytest", specifier = ">=9.0.2" }]
+test = [
+    { name = "aiofiles", specifier = ">=25.1.0" },
+    { name = "pytest", specifier = ">=9.0.2" },
+]
 
 [[package]]
 name = "tomli"


### PR DESCRIPTION
## Summary

- Fix `PipelineOutput.report` to skip temp files when counting errors and outputs, so in-flight atomic writes are not reported as real results
- Move `aiofiles` from runtime to test-only dependencies, matching its actual usage
- Refresh docs and examples to match current `tigerflow report` output
- Update stale `tests/user/` references to `tests/manual/`

## Testing

- [x] Unit tests
- [x] Integration tests (excluding Slurm ones)