### PR TITLE
Add pipeline integration tests

### DIFF
--- a/src/tigerflow/pipeline.py
+++ b/src/tigerflow/pipeline.py
@@ -184,12 +184,7 @@ class Pipeline:
             self._start_tasks()
             logger.info("All tasks started, beginning pipeline tracking loop")
             while not self._shutdown_event.is_set():
-                self._check_task_status()
-                self._handle_task_timeout()
-                self._stage_new_files()
-                self._report_failed_files()
-                self._handle_processed_files()
-                self._check_inactivity()
+                self._run_tracking_cycle()
                 self._shutdown_event.wait(timeout=settings.pipeline_poll_interval)
         finally:
             self._handle_processed_files()
@@ -212,6 +207,20 @@ class Pipeline:
                 self._pid_file.unlink(missing_ok=True)
             if self._received_signal is not None:
                 sys.exit(128 + self._received_signal)
+
+    def _run_tracking_cycle(self):
+        """Run one iteration of the pipeline tracking loop.
+
+        `_handle_task_timeout` reads the task status that `_check_task_status`
+        refreshes, so it must not run before it; a stale status resubmits a
+        Slurm job that has already been replaced.
+        """
+        self._check_task_status()
+        self._handle_task_timeout()
+        self._stage_new_files()
+        self._report_failed_files()
+        self._handle_processed_files()
+        self._check_inactivity()
 
     def _start_tasks(self):
         tasks_meta = [

--- a/tests/integration/pipeline/conftest.py
+++ b/tests/integration/pipeline/conftest.py
@@ -1,0 +1,157 @@
+"""Shared fixtures for Pipeline tests.
+
+Pipeline is exercised in-process against real temp directories. Task
+subprocesses are faked (see `fake_popen`) but the config models, staging
+middleware, and filesystem layout are all real.
+
+Config builders and fakes live in `helpers.py`.
+"""
+
+import subprocess
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from tigerflow.logconfig import logger
+from tigerflow.pipeline import Pipeline
+
+from .helpers import FakePopen, PipelineFactory, task_spec
+
+
+@pytest.fixture
+def input_dir(tmp_path: Path) -> Path:
+    path = tmp_path / "input"
+    path.mkdir(exist_ok=True)
+    return path
+
+
+@pytest.fixture
+def output_dir(tmp_path: Path) -> Path:
+    path = tmp_path / "output"
+    path.mkdir(exist_ok=True)
+    return path
+
+
+@pytest.fixture
+def pipeline_factory(
+    tmp_path: Path, input_dir: Path, output_dir: Path
+) -> PipelineFactory:
+    """Return a callable that builds a Pipeline over the `input_dir`/`output_dir` fixtures.
+
+    Tasks are given as config dicts (see `task_spec`) so tests can construct
+    dependency chains and multi-terminal-task graphs, not just a single task.
+    CLI validation is patched out because no task subprocess is spawned.
+    """
+
+    def factory(
+        tasks: list[dict] | None = None,
+        *,
+        staging: dict | None = None,
+        **kwargs,
+    ) -> Pipeline:
+        config_file = tmp_path / "config.yaml"
+
+        config: dict = {"tasks": tasks if tasks is not None else [task_spec()]}
+        if staging is not None:
+            config["staging"] = staging
+        config_file.write_text(yaml.dump(config))
+
+        with patch("tigerflow.pipeline.validate_task_cli", return_value=True):
+            return Pipeline(
+                config_file=config_file,
+                input_dir=input_dir,
+                output_dir=output_dir,
+                **kwargs,
+            )
+
+    return factory
+
+
+@pytest.fixture(autouse=True)
+def fake_popen() -> Iterator[list[FakePopen]]:
+    """Patch subprocess spawning so `_start_tasks` creates FakePopen objects.
+
+    Autouse because the failure mode is silent: `_start_tasks` never waits on
+    the processes it spawns, so a test that missed this fixture still passes
+    green while leaking a real bash process that outlives the run.
+
+    Yields a list receiving each FakePopen in creation order.
+    """
+    created: list[FakePopen] = []
+
+    def spawn(*args, **kwargs) -> FakePopen:
+        process = FakePopen(*args, **kwargs)
+        created.append(process)
+        return process
+
+    with patch.object(subprocess, "Popen", spawn):
+        yield created
+
+
+@pytest.fixture
+def stop_after_one_cycle(monkeypatch: pytest.MonkeyPatch) -> Callable[[Pipeline], None]:
+    """Return a callable that arms a pipeline so a later `run()` does one cycle.
+
+    Shutdown is requested from inside the cycle rather than before `run()`, so
+    the pipeline reaches its normal steady state (tasks started and polled at
+    least once) before the shutdown path is exercised. The poll interval is
+    shortened so the post-cycle wait does not stall the test.
+    """
+
+    def setup(pipeline: Pipeline) -> None:
+        monkeypatch.setattr("tigerflow.pipeline.settings.pipeline_poll_interval", 1)
+
+        original_cycle = pipeline._run_tracking_cycle
+
+        def cycle_then_stop():
+            # Shutdown must be requested even if the cycle raises, otherwise a
+            # failing cycle leaves run() looping until the idle timeout.
+            try:
+                original_cycle()
+            finally:
+                pipeline._shutdown_event.set()
+
+        monkeypatch.setattr(pipeline, "_run_tracking_cycle", cycle_then_stop)
+
+    return setup
+
+
+@pytest.fixture
+def error_logs() -> Iterator[list[str]]:
+    """Yield a list collecting the message of every ERROR record logged.
+
+    Tigerflow logs through loguru, so pytest's `caplog` sees nothing and
+    capture requires adding a sink.
+    """
+    records: list[str] = []
+
+    sink_id = logger.add(
+        lambda message: records.append(message.record["message"]), level="ERROR"
+    )
+    try:
+        yield records
+    finally:
+        logger.remove(sink_id)
+
+
+@pytest.fixture(autouse=True)
+def reset_logger_sinks():
+    """Drop file sinks added by `Pipeline.run()` after each test.
+
+    Loguru sinks are global, so without this a sink keeps pointing at a
+    deleted tmp_path directory and later tests fail on write. Only sinks
+    added during the test are removed; the stderr sink installed by
+    tigerflow.logconfig at import time must survive for later tests.
+
+    Reads `logger._core.handlers` because loguru exposes no public API for
+    listing sink IDs.
+    """
+    existing_ids = set(logger._core.handlers)  # ty: ignore[unresolved-attribute]
+
+    yield
+
+    for sink_id in set(logger._core.handlers) - existing_ids:  # ty: ignore[unresolved-attribute]
+        logger.remove(sink_id)

--- a/tests/integration/pipeline/helpers.py
+++ b/tests/integration/pipeline/helpers.py
@@ -1,0 +1,122 @@
+"""Config builders and fakes shared across Pipeline tests.
+
+Kept out of `conftest.py` so that file holds fixtures only, which pytest
+supplies implicitly, rather than a mix of implicit fixtures and symbols
+tests import by name.
+"""
+
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+
+from tigerflow.models import TaskStatus, TaskStatusKind
+from tigerflow.pipeline import Pipeline
+
+DEFAULT_TASK_NAME = "echo"
+
+# Any importable module works: validate_task_cli is patched out by pipeline_factory
+DEFAULT_MODULE = "tigerflow.library.echo"
+
+# Type of the `pipeline_factory` fixture, which tests annotate on every request
+PipelineFactory = Callable[..., Pipeline]
+
+
+def task_spec(
+    name: str = DEFAULT_TASK_NAME,
+    *,
+    kind: str = "local",
+    depends_on: str | None = None,
+    input_ext: str = ".txt",
+    output_ext: str = ".txt",
+    keep_output: bool = False,
+    **extra,
+) -> dict:
+    """Build a single task config dict, overriding only what a test cares about."""
+    spec = {
+        "name": name,
+        "kind": kind,
+        "module": DEFAULT_MODULE,
+        "input_ext": input_ext,
+        "output_ext": output_ext,
+        "keep_output": keep_output,
+    }
+    if depends_on is not None:
+        spec["depends_on"] = depends_on
+    spec.update(extra)
+    return spec
+
+
+class FakePopen(subprocess.Popen):
+    """Stand-in for a task subprocess, so tests never spawn real processes.
+
+    Nothing spawns because `__init__` never calls `super()`, which is where the
+    real class forks. That also leaves inherited methods without the state they
+    read, so anything Pipeline reaches for beyond `poll`/`terminate`/`pid`
+    raises AttributeError instead of acting on a pid that is not ours.
+
+    Set `exit_code` to make a task look like it died.
+    """
+
+    def __init__(self, *args, **kwargs):
+        # Popen.__del__ reads _child_created to tell whether a child is owed a reap
+        self._child_created = False
+        self.args = args
+        self.pid = 424242
+        self.exit_code: int | None = None
+        self.terminate_calls = 0
+
+    def poll(self) -> int | None:
+        return self.exit_code
+
+    def terminate(self):
+        self.terminate_calls += 1
+        # A terminated process must stop reporting itself as alive, otherwise
+        # the shutdown loop in Pipeline.run() never exits
+        if self.exit_code is None:
+            self.exit_code = -15
+
+
+def start_fake_tasks(pipeline: Pipeline) -> None:
+    """Register a fake subprocess per task so a cycle can poll task status.
+
+    `_check_task_status()` looks tasks up in `_subprocesses`, which only
+    `_start_tasks()` fills — and tests driving cycles never call it. Status is
+    set separately because the constructor starts tasks INACTIVE.
+    """
+    for task in pipeline._config.tasks:
+        pipeline._subprocesses[task.name] = FakePopen()
+        pipeline._task_status[task.name] = TaskStatus(kind=TaskStatusKind.ACTIVE)
+
+
+def stage_file(pipeline: Pipeline, input_dir: Path, file_id: str) -> None:
+    """Write an input file and stage it through the real staging path.
+
+    Goes through `_stage_new_files` rather than writing the symlink directly,
+    so callers keep exercising staging.
+    """
+    (input_dir / f"{file_id}{pipeline._config.root_input_ext}").write_text("payload")
+    pipeline._stage_new_files()
+
+
+def write_output(pipeline: Pipeline, file_id: str, *, task: str | None = None) -> None:
+    """Write a task output, as the task's worker would on success.
+
+    `task` may be omitted only for a single-task pipeline, where there is no
+    ambiguity and naming the task would force the caller to know which name
+    the pipeline was built with.
+    """
+    tasks = pipeline._config.tasks
+    if task is None:
+        if len(tasks) > 1:
+            raise ValueError(
+                f"Pipeline has {len(tasks)} tasks; pass task= to pick one of "
+                f"{[t.name for t in tasks]}"
+            )
+        spec = tasks[0]
+    else:
+        spec = next((t for t in tasks if t.name == task), None)
+        if spec is None:
+            raise ValueError(
+                f"No task named {task!r}; pipeline has {[t.name for t in tasks]}"
+            )
+    (spec.output_dir / f"{file_id}{spec.output_ext}").write_text("done")

--- a/tests/integration/pipeline/test_file_completion.py
+++ b/tests/integration/pipeline/test_file_completion.py
@@ -1,0 +1,169 @@
+"""Tests for how Pipeline cleans up files that finished every task.
+
+A worker that sees a symlink still present but the task output already gone
+treats the file as unprocessed and redoes it, so cleanup must never leave a
+completed file in that state.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tigerflow.pipeline import Pipeline
+
+from .helpers import PipelineFactory, stage_file, task_spec, write_output
+
+
+def setup_completed_file(pipeline: Pipeline, input_dir: Path, file_id: str):
+    """Stage a file and write its task output so it looks fully processed."""
+    stage_file(pipeline, input_dir, file_id)
+    write_output(pipeline, file_id)
+
+
+class TestCleanupOrdering:
+    """Cleanup must never leave a file in a state a worker would redo."""
+
+    @pytest.mark.parametrize("delete_input", [False, True])
+    def test_no_unsafe_intermediate_state(
+        self,
+        pipeline_factory: PipelineFactory,
+        input_dir: Path,
+        delete_input: bool,
+    ):
+        """Check the cleanup invariants at the moment each unlink happens.
+
+        Asserting the invariants rather than the call sequence keeps the test
+        green for any reordering that is still safe, and makes a failure point
+        at the hazard instead of at a position in a list.
+        """
+        pipeline = pipeline_factory(delete_input=delete_input)
+        setup_completed_file(pipeline, input_dir, "f1")
+
+        finished_file = pipeline._finished_dir / "f1.txt"
+        symlink_file = pipeline._symlinks_dir / "f1.txt"
+        output_file = pipeline._config.tasks[0].output_dir / "f1.txt"
+
+        original_unlink = Path.unlink
+        checked = set()
+
+        def checked_unlink(self, *args, **kwargs):
+            if self == symlink_file:
+                # A worker that finds no marker treats the file as unprocessed
+                assert finished_file.exists(), ".finished must be recorded first"
+                checked.add("symlink")
+            elif self == output_file:
+                # A live symlink with no output also makes a worker redo the file
+                assert not symlink_file.exists(), "Symlink must be removed first"
+                checked.add("output")
+            return original_unlink(self, *args, **kwargs)
+
+        with patch.object(Path, "unlink", checked_unlink):
+            pipeline._handle_processed_files()
+
+        # Without this, a cleanup that skips an unlink entirely would pass
+        assert checked == {"symlink", "output"}
+
+    def test_output_unlink_tolerates_missing_file(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """Output deletion should not raise if the file disappears mid-cleanup.
+
+        Simulates another process deleting the output between detection and
+        the unlink call.
+        """
+        pipeline = pipeline_factory()
+        setup_completed_file(pipeline, input_dir, "f1")
+
+        task = pipeline._config.tasks[0]
+        output_file = task.output_dir / "f1.txt"
+
+        original_unlink = Path.unlink
+        deleted_early = False
+
+        def unlink_with_race(self, *args, **kwargs):
+            nonlocal deleted_early
+            if self == output_file and not deleted_early:
+                deleted_early = True
+                original_unlink(self)  # Another process wins the race
+            return original_unlink(self, *args, **kwargs)
+
+        with patch.object(Path, "unlink", unlink_with_race):
+            pipeline._handle_processed_files()
+
+        assert deleted_early
+        assert (pipeline._finished_dir / "f1.txt").exists()
+        assert not (pipeline._symlinks_dir / "f1.txt").exists()
+
+
+class TestCleanupState:
+    """Filesystem state after a file completes every task."""
+
+    def test_state_after_processing(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """Completion records the marker and clears staged, output, and input."""
+        pipeline = pipeline_factory(delete_input=True)
+        task = pipeline._config.tasks[0]
+
+        setup_completed_file(pipeline, input_dir, "f1")
+
+        pipeline._handle_processed_files()
+
+        assert (pipeline._finished_dir / "f1.txt").exists()
+        assert not (pipeline._symlinks_dir / "f1.txt").exists()
+        assert not (task.output_dir / "f1.txt").exists()
+        assert not (input_dir / "f1.txt").exists()
+
+    def test_preserves_input_when_not_deleting(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        pipeline = pipeline_factory(delete_input=False)
+        task = pipeline._config.tasks[0]
+
+        setup_completed_file(pipeline, input_dir, "f1")
+
+        pipeline._handle_processed_files()
+
+        assert (pipeline._finished_dir / "f1.txt").exists()
+        assert not (pipeline._symlinks_dir / "f1.txt").exists()
+        assert not (task.output_dir / "f1.txt").exists()
+        assert (input_dir / "f1.txt").exists()
+
+    def test_multiple_files(self, pipeline_factory: PipelineFactory, input_dir: Path):
+        pipeline = pipeline_factory()
+        task = pipeline._config.tasks[0]
+
+        for i in range(3):
+            setup_completed_file(pipeline, input_dir, f"file{i}")
+
+        pipeline._handle_processed_files()
+
+        for i in range(3):
+            assert (pipeline._finished_dir / f"file{i}.txt").exists()
+            assert not (pipeline._symlinks_dir / f"file{i}.txt").exists()
+            assert not (task.output_dir / f"file{i}.txt").exists()
+
+    def test_state_after_processing_with_differing_exts(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """Completion derives the file ID from `output_ext` but names files with `input_ext`.
+
+        From one ID this step writes the finished marker and removes the
+        symlink and input file, all at the root `input_ext`, while the task
+        output it deletes carries `output_ext`.
+        """
+        pipeline = pipeline_factory(
+            [task_spec(input_ext=".txt", output_ext=".json")], delete_input=True
+        )
+        task = pipeline._config.tasks[0]
+
+        setup_completed_file(pipeline, input_dir, "f1")
+        assert (task.output_dir / "f1.json").exists()
+
+        pipeline._handle_processed_files()
+
+        assert (pipeline._finished_dir / "f1.txt").exists()
+        assert not (pipeline._symlinks_dir / "f1.txt").exists()
+        assert not (input_dir / "f1.txt").exists()
+        assert not (task.output_dir / "f1.json").exists()

--- a/tests/integration/pipeline/test_file_staging.py
+++ b/tests/integration/pipeline/test_file_staging.py
@@ -1,0 +1,347 @@
+"""Tests for selecting input files and exposing pipeline state to middleware.
+
+Staging turns files in the input directory into symlinks the root tasks can
+see. Middleware decides which candidates make the cut, and reads counts from
+a StagingContext the pipeline assembles from the filesystem.
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from tigerflow.pipeline import Pipeline
+from tigerflow.staging import StagingContext
+
+from .helpers import PipelineFactory, task_spec
+
+DUPLICATING_STEP = {
+    "kind": "callable",
+    "function": f"{__name__}:duplicate_candidates",
+}
+
+
+def duplicate_candidates(candidates: list[Path], context: StagingContext) -> list[Path]:
+    """Staging middleware that returns its first candidate twice."""
+    return [candidates[0], candidates[0]] if candidates else []
+
+
+class TestStagingSelection:
+    """Which input files become staged symlinks."""
+
+    def test_stages_matching_extension_only(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """Only files matching the root input extension are staged."""
+        pipeline = pipeline_factory()
+        (input_dir / "keep.txt").write_text("yes")
+        (input_dir / "skip.csv").write_text("no")
+
+        pipeline._stage_new_files()
+
+        staged = {f.name for f in pipeline._symlinks_dir.iterdir()}
+        assert staged == {"keep.txt"}
+
+    def test_ignores_directories(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """A directory whose name matches the input extension is not staged."""
+        pipeline = pipeline_factory()
+        (input_dir / "adir.txt").mkdir()
+
+        pipeline._stage_new_files()
+
+        assert list(pipeline._symlinks_dir.iterdir()) == []
+
+    def test_staged_symlink_resolves_to_input(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """The staged entry is a symlink pointing at the original input file."""
+        pipeline = pipeline_factory()
+        source = input_dir / "a.txt"
+        source.write_text("payload")
+
+        pipeline._stage_new_files()
+
+        symlink_file = pipeline._symlinks_dir / "a.txt"
+        assert symlink_file.is_symlink()
+        assert symlink_file.resolve() == source.resolve()
+        assert symlink_file.read_text() == "payload"
+
+    def test_middleware_limits_staging(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """A max_batch step caps how many files are staged per cycle."""
+        pipeline = pipeline_factory(
+            staging={"steps": [{"kind": "max_batch", "count": 2}]}
+        )
+        for i in range(5):
+            (input_dir / f"file{i}.txt").write_text("x")
+
+        pipeline._stage_new_files()
+
+        assert len(list(pipeline._symlinks_dir.iterdir())) == 2
+
+    def test_duplicate_candidates_propagate_error(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """Middleware returning the same file twice fails staging.
+
+        `_stage_new_files` symlinks each returned candidate without checking
+        for duplicates, so the second symlink for a file collides. Failing
+        here is correct: middleware that returns duplicates is buggy, and
+        silently deduping would hide it. What is wrong is how far the failure
+        spreads, which `test_duplicate_candidates_do_not_end_run` pins down.
+        """
+        pipeline = pipeline_factory(staging={"steps": [DUPLICATING_STEP]})
+        (input_dir / "a.txt").write_text("payload")
+
+        with pytest.raises(FileExistsError):
+            pipeline._stage_new_files()
+
+    @pytest.mark.xfail(
+        reason="Middleware output is unvalidated and the resulting error "
+        "propagates out of the tracking loop, terminating the entire pipeline",
+        strict=True,
+    )
+    def test_duplicate_candidates_do_not_end_run(
+        self,
+        pipeline_factory: PipelineFactory,
+        input_dir: Path,
+        stop_after_one_cycle: Callable[[Pipeline], None],
+    ):
+        """A buggy staging step should cost one cycle, not the whole run.
+
+        Middleware faults are already non-fatal in the case that was anticipated:
+        `CallableMiddleware` catches every exception from the user callable,
+        warns, and stages nothing that cycle. The gap is a callable that raises
+        nothing itself and instead returns bad data.
+
+        Duplicates are one such fault, and the one covered here; returning
+        `None` or `list[str]` ends the run the same way, and a fabricated path
+        creates a dangling symlink with no error at all.
+
+        `stop_after_one_cycle` forces shutdown because today the error ends the
+        run on its own; once fixed, an unbounded `run()` would spin until the
+        idle timeout.
+        """
+        pipeline = pipeline_factory(staging={"steps": [DUPLICATING_STEP]})
+        (input_dir / "a.txt").write_text("payload")
+        stop_after_one_cycle(pipeline)
+
+        pipeline.run()  # Must not raise
+
+
+class TestStagingContext:
+    """Counts handed to middleware must reflect real pipeline state."""
+
+    def test_counts_waiting_files(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """Unstaged input files are reported as waiting."""
+        pipeline = pipeline_factory()
+        for i in range(3):
+            (input_dir / f"f{i}.txt").write_text("x")
+
+        context = pipeline._build_staging_context()
+
+        assert context.waiting == 3
+        assert context.staged == 0
+        assert context.completed == 0
+
+    def test_counts_shift_after_staging(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """Staging moves files from waiting to staged."""
+        pipeline = pipeline_factory()
+        (input_dir / "a.txt").write_text("x")
+
+        pipeline._stage_new_files()
+        context = pipeline._build_staging_context()
+
+        assert context.waiting == 0
+        assert context.staged == 1
+
+    def test_counts_completed_files(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """A file that finished every task moves from the staged count to completed."""
+        pipeline = pipeline_factory()
+        (input_dir / "a.txt").write_text("x")
+        pipeline._stage_new_files()
+
+        task = pipeline._config.tasks[0]
+        (task.output_dir / "a.txt").write_text("done")
+        pipeline._handle_processed_files()
+
+        context = pipeline._build_staging_context()
+
+        assert context.completed == 1
+        assert context.staged == 0
+
+    def test_staged_count_excludes_failures(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """Files that errored are counted as failed, not staged."""
+        pipeline = pipeline_factory()
+        (input_dir / "a.txt").write_text("x")
+        pipeline._stage_new_files()
+
+        task = pipeline._config.tasks[0]
+        (task.output_dir / "a.err").write_text("boom")
+        pipeline._report_failed_files()
+
+        context = pipeline._build_staging_context()
+
+        assert context.failed == 1
+        assert context.staged == 0
+
+    def test_max_staged_respects_capacity(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """A max_staged step counts files already in flight, not just this batch."""
+        pipeline = pipeline_factory(
+            staging={"steps": [{"kind": "max_staged", "count": 2}]}
+        )
+        for i in range(5):
+            (input_dir / f"f{i}.txt").write_text("x")
+
+        pipeline._stage_new_files()
+        first_batch = {f.name for f in pipeline._symlinks_dir.iterdir()}
+        assert len(first_batch) == 2
+
+        pipeline._stage_new_files()
+        staged = {f.name for f in pipeline._symlinks_dir.iterdir()}
+        assert staged == first_batch, (
+            "Capacity is already full, so no further file should be staged"
+        )
+
+    def test_counts_stay_consistent_in_mixed_state(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """All four counts hold together when staged, completed, and failed coexist.
+
+        The tests above each set up one state at a time, so this is the only
+        place `waiting`, `staged`, `completed`, and `failed` are all pinned
+        against each other. Four files are staged, one completes, one fails:
+        completion removes a symlink and failure does not, so `staged` is 3
+        symlinks minus 1 recorded failure. The counts are deliberately unequal
+        because one file per state lets several wrong formulas land on the
+        right answer.
+        """
+        pipeline = pipeline_factory()
+        for i in range(4):
+            (input_dir / f"f{i}.txt").write_text("x")
+        pipeline._stage_new_files()
+
+        task = pipeline._config.tasks[0]
+        (task.output_dir / "f0.txt").write_text("done")
+        (task.output_dir / "f1.err").write_text("boom")
+        pipeline._report_failed_files()
+        pipeline._handle_processed_files()
+
+        context = pipeline._build_staging_context()
+
+        counts = (context.waiting, context.staged, context.completed, context.failed)
+        assert counts == (0, 2, 1, 1)
+
+    @pytest.mark.xfail(
+        reason="Failures are subtracted as a per-task total, so a file failing "
+        "in two fan-out tasks is discounted twice and staged undercounts the "
+        "files still live",
+        strict=True,
+    )
+    def test_staged_discounts_each_failed_file_once(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """A file failing in several tasks must free one staging slot, not one per task.
+
+        Excluding failures from `staged` is intended: a file that can no longer
+        complete should not hold a slot against live work. Its symlink stays
+        because the other tasks read the same directory, so `staged` cannot
+        simply be the symlink count.
+
+        The defect is that the exclusion mixes two units. `_build_staging_context`
+        subtracts `failed`, which counts error *files* across tasks, from a
+        symlink count that holds each input *file* once.
+
+        Here two files are staged under a cap of 2, and one of them fails in
+        `alpha` and `beta` while `gamma` has not processed it yet. The untouched
+        file still holds a slot and the failed one frees a single slot however
+        many tasks recorded it, so `staged` should be 1, but 2 - 2 reports 0.
+
+        Note that `failed` reading 2 for one bad input is not itself the bug.
+        It is documented as a count of error files, so 2 is what it should
+        report. Only the subtraction is wrong.
+
+        `test_fan_out_failures_do_not_cut_the_run_short` in test_lifecycle.py
+        covers the other symptom of this mismatch.
+        """
+        pipeline = pipeline_factory(
+            [task_spec("alpha"), task_spec("beta"), task_spec("gamma")],
+            staging={"steps": [{"kind": "max_staged", "count": 2}]},
+        )
+        alpha, beta, _gamma = pipeline._config.tasks
+        for i in range(6):
+            (input_dir / f"f{i}.txt").write_text("x")
+
+        pipeline._stage_new_files()
+        staged = [f.name for f in pipeline._symlinks_dir.iterdir()]
+        assert len(staged) == 2, "Cap should admit exactly 2 on the first pass"
+
+        failed_name = staged[0]
+        failed_stem = Path(failed_name).stem
+        for task in (alpha, beta):
+            (task.output_dir / f"{failed_stem}.err").write_text("boom")
+        pipeline._report_failed_files()
+
+        assert (pipeline._symlinks_dir / failed_name).exists(), (
+            "Failure must not remove the symlink the remaining task reads from"
+        )
+
+        assert pipeline._build_staging_context().staged == 1, (
+            "One of the 2 staged files is untouched and the other can no longer "
+            "complete, so one slot is occupied no matter how many tasks recorded "
+            "the failure"
+        )
+
+
+class TestFailureReporting:
+    """Error files are attributed per task and announced once each."""
+
+    def test_reports_each_error_once(
+        self, pipeline_factory: PipelineFactory, error_logs: list[str]
+    ):
+        """An .err file present across repeated scans is logged only the first time.
+
+        The tracking loop rescans every cycle, so an already-seen file must
+        stay silent. Asserting on the log rather than on `_task_error_filenames`
+        is deliberate: that is a set, so it holds one entry either way.
+        """
+        pipeline = pipeline_factory()
+        task = pipeline._config.tasks[0]
+        (task.output_dir / "a.err").write_text("boom")
+
+        pipeline._report_failed_files()
+        pipeline._report_failed_files()
+
+        assert len(error_logs) == 1
+        assert task.name in error_logs[0]
+
+    def test_tracks_errors_per_task(self, pipeline_factory: PipelineFactory):
+        """Errors are attributed to the task that produced them.
+
+        The tasks fan out from the same input rather than forming a chain, so
+        one file can fail in both. `a.err` must then appear under both task
+        names, which is what a single shared set would get wrong.
+        """
+        pipeline = pipeline_factory([task_spec("alpha"), task_spec("beta")])
+        alpha, beta = pipeline._config.tasks
+        (alpha.output_dir / "a.err").write_text("boom")
+        (beta.output_dir / "a.err").write_text("boom")
+        (beta.output_dir / "b.err").write_text("boom")
+
+        pipeline._report_failed_files()
+
+        assert pipeline._task_error_filenames["alpha"] == {"a.err"}
+        assert pipeline._task_error_filenames["beta"] == {"a.err", "b.err"}

--- a/tests/integration/pipeline/test_init.py
+++ b/tests/integration/pipeline/test_init.py
@@ -1,0 +1,194 @@
+"""Tests for the cleanup Pipeline performs at construction.
+
+A new Pipeline inherits whatever the previous run left behind, so __init__
+reconciles that state: finished files lose their symlinks and task outputs,
+broken symlinks are dropped, and partial or misnamed outputs are removed.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from tigerflow.models import PipelineOutput
+from tigerflow.utils import TEMP_FILE_PREFIX
+
+from .helpers import DEFAULT_TASK_NAME, PipelineFactory, task_spec
+
+
+def make_prior_run_layout(output_dir: Path) -> PipelineOutput:
+    """Build the layout a prior run would have left, before Pipeline exists."""
+    layout = PipelineOutput(output_dir)
+    layout.symlinks.mkdir(parents=True, exist_ok=True)
+    layout.finished.mkdir(parents=True, exist_ok=True)
+    return layout
+
+
+def make_task_output_dir(layout: PipelineOutput, name: str = DEFAULT_TASK_NAME) -> Path:
+    path = layout.internal / name
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+class TestInitCleanup:
+    """Leftover state from a prior run should be reconciled on construction."""
+
+    def test_finished_file_with_lingering_symlink_and_outputs(
+        self,
+        pipeline_factory: PipelineFactory,
+        input_dir: Path,
+        output_dir: Path,
+    ):
+        """Finished file + leftover symlink + task output should all be cleaned."""
+        input_file = input_dir / "doc1.txt"
+        input_file.write_text("content")
+
+        layout = make_prior_run_layout(output_dir)
+        (layout.finished / "doc1.txt").touch()
+
+        symlink_file = layout.symlinks / "doc1.txt"
+        symlink_file.symlink_to(input_file)
+
+        output_file = make_task_output_dir(layout) / "doc1.txt"
+        output_file.write_text("stale output")
+
+        pipeline_factory()
+
+        assert not symlink_file.exists()
+        assert not output_file.exists()
+
+    def test_broken_symlink_with_orphaned_outputs(
+        self,
+        pipeline_factory: PipelineFactory,
+        input_dir: Path,
+        output_dir: Path,
+    ):
+        """Broken symlink (target deleted) + task outputs should be cleaned."""
+        layout = make_prior_run_layout(output_dir)
+        symlink_file = layout.symlinks / "gone.txt"
+        symlink_file.symlink_to(input_dir / "gone.txt")
+
+        output_file = make_task_output_dir(layout) / "gone.txt"
+        output_file.write_text("orphaned")
+
+        pipeline_factory()
+
+        # `exists()` follows the link and its target never existed, so it would
+        # pass without any cleanup; `is_symlink()` checks the link itself.
+        assert not symlink_file.is_symlink()
+        assert not output_file.exists()
+
+    @pytest.mark.parametrize("delete_input", [False, True])
+    def test_finished_input_follows_delete_input(
+        self,
+        pipeline_factory: PipelineFactory,
+        input_dir: Path,
+        output_dir: Path,
+        delete_input: bool,
+    ):
+        """A finished file's input is deleted only when delete_input is set."""
+        input_file = input_dir / "doc1.txt"
+        input_file.write_text("content")
+
+        layout = make_prior_run_layout(output_dir)
+        (layout.finished / "doc1.txt").touch()
+
+        pipeline_factory(delete_input=delete_input)
+
+        assert input_file.exists() is not delete_input
+
+    def test_non_symlink_junk_in_symlinks_dir(
+        self, pipeline_factory: PipelineFactory, output_dir: Path
+    ):
+        layout = make_prior_run_layout(output_dir)
+        junk_file = layout.symlinks / "not_a_symlink.txt"
+        junk_file.write_text("junk")
+
+        pipeline_factory()
+
+        assert not junk_file.exists()
+
+    def test_valid_symlink_preserved(
+        self,
+        pipeline_factory: PipelineFactory,
+        input_dir: Path,
+        output_dir: Path,
+    ):
+        input_file = input_dir / "active.txt"
+        input_file.write_text("in progress")
+
+        layout = make_prior_run_layout(output_dir)
+        symlink_file = layout.symlinks / "active.txt"
+        symlink_file.symlink_to(input_file)
+
+        pipeline_factory()
+
+        assert symlink_file.is_symlink()
+
+    def test_temp_files_with_output_ext_removed(
+        self, pipeline_factory: PipelineFactory, output_dir: Path
+    ):
+        layout = make_prior_run_layout(output_dir)
+        task_output_dir = make_task_output_dir(layout)
+
+        temp_file = task_output_dir / f"{TEMP_FILE_PREFIX}abc123.txt"
+        temp_file.write_text("partial")
+        output_file = task_output_dir / "doc1.txt"
+        output_file.write_text("complete")
+
+        pipeline_factory()
+
+        assert not temp_file.exists()
+        assert output_file.exists()
+
+    def test_extensionless_file_removed(
+        self, pipeline_factory: PipelineFactory, output_dir: Path
+    ):
+        """A file not matching the output extension should be removed.
+
+        Cleanup keys off the output extension rather than the temp prefix, so
+        an extensionless file is discarded even without the prefix.
+        """
+        layout = make_prior_run_layout(output_dir)
+        task_output_dir = make_task_output_dir(layout)
+
+        extensionless_file = task_output_dir / "somefile"
+        extensionless_file.write_text("not a temp file")
+
+        pipeline_factory()
+
+        assert not extensionless_file.exists()
+
+    @pytest.mark.parametrize("delete_input", [False, True])
+    def test_orphaned_outputs_cleaned_at_task_ext(
+        self,
+        pipeline_factory: PipelineFactory,
+        input_dir: Path,
+        output_dir: Path,
+        delete_input: bool,
+    ):
+        """Orphan cleanup resolves each path at the extension that names it.
+
+        File IDs come from the finished dir, where names carry the root input
+        extension. From one ID this step deletes two differently named files:
+        the task output at `output_ext`, and the input file at `input_ext`.
+        """
+        input_file = input_dir / "doc1.txt"
+        input_file.write_text("content")
+
+        layout = make_prior_run_layout(output_dir)
+        (layout.finished / "doc1.txt").touch()
+
+        symlink_file = layout.symlinks / "doc1.txt"
+        symlink_file.symlink_to(input_file)
+
+        output_file = make_task_output_dir(layout) / "doc1.json"
+        output_file.write_text("stale output")
+
+        pipeline_factory(
+            [task_spec(input_ext=".txt", output_ext=".json")],
+            delete_input=delete_input,
+        )
+
+        assert not symlink_file.exists()
+        assert not output_file.exists()
+        assert input_file.exists() is not delete_input

--- a/tests/integration/pipeline/test_lifecycle.py
+++ b/tests/integration/pipeline/test_lifecycle.py
@@ -1,0 +1,304 @@
+"""Tests for the pipeline tracking loop, shutdown, and exit codes.
+
+Tests drive `_run_tracking_cycle()` directly instead of `run()` wherever the
+shutdown path is not under test, which keeps them free of sleeps and signal
+delivery.
+
+Note when adding tests here: `run()` calls `_handle_processed_files()` once
+more in its `finally` block, so final state after `run()` is one completion
+pass ahead of the same number of bare cycle calls.
+"""
+
+import signal
+from collections.abc import Callable
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from tigerflow.pipeline import Pipeline
+
+from .helpers import (
+    FakePopen,
+    PipelineFactory,
+    start_fake_tasks,
+    task_spec,
+    write_output,
+)
+
+
+class TestTrackingCycle:
+    """Emergent behavior across repeated tracking cycles."""
+
+    def test_stages_then_completes_across_cycles(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """A staged file is completed once its task produces output."""
+        pipeline = pipeline_factory()
+        start_fake_tasks(pipeline)
+
+        (input_dir / "a.txt").write_text("payload")
+
+        pipeline._run_tracking_cycle()
+        assert (pipeline._symlinks_dir / "a.txt").is_symlink()
+        assert not (pipeline._finished_dir / "a.txt").exists()
+
+        write_output(pipeline, "a")
+
+        pipeline._run_tracking_cycle()
+        assert (pipeline._finished_dir / "a.txt").exists()
+        assert not (pipeline._symlinks_dir / "a.txt").exists()
+
+    def test_file_staged_only_once(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """Repeated cycles must not restage a file already being processed."""
+        pipeline = pipeline_factory()
+        start_fake_tasks(pipeline)
+
+        (input_dir / "a.txt").write_text("payload")
+
+        for _ in range(3):
+            pipeline._run_tracking_cycle()
+
+        staged = list(pipeline._symlinks_dir.iterdir())
+        assert len(staged) == 1
+
+    def test_finished_file_not_reprocessed(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """A completed file must not be restaged when it stays in input_dir.
+
+        `delete_input` defaults to False, so the input file remains on disk
+        after completion and would otherwise look like a fresh candidate.
+        """
+        pipeline = pipeline_factory()
+        start_fake_tasks(pipeline)
+
+        (input_dir / "a.txt").write_text("payload")
+        pipeline._run_tracking_cycle()
+        write_output(pipeline, "a")
+
+        pipeline._run_tracking_cycle()
+        assert (pipeline._finished_dir / "a.txt").exists()
+
+        pipeline._run_tracking_cycle()
+        assert not (pipeline._symlinks_dir / "a.txt").exists(), (
+            "Finished file should not be restaged"
+        )
+
+
+class TestKeepOutput:
+    """Outputs of tasks configured with keep_output land in the output dir."""
+
+    def test_kept_output_survives_cleanup(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """The copy in output_dir must outlive deletion of the intermediate file."""
+        pipeline = pipeline_factory([task_spec(keep_output=True)])
+        start_fake_tasks(pipeline)
+
+        (input_dir / "a.txt").write_text("payload")
+        pipeline._run_tracking_cycle()
+        write_output(pipeline, "a")
+        pipeline._run_tracking_cycle()
+
+        task = pipeline._config.tasks[0]
+        kept = pipeline._output_dir / task.name / "a.txt"
+        assert kept.exists(), "Kept output should be copied to the output directory"
+        assert not (task.output_dir / "a.txt").exists(), (
+            "Intermediate output should still be cleaned up"
+        )
+
+
+class TestInactivity:
+    """Idle timeout drives shutdown once nothing is left to process."""
+
+    def test_idle_timeout_must_be_positive(self, pipeline_factory: PipelineFactory):
+        """A non-positive idle timeout is rejected at construction."""
+        with pytest.raises(ValueError, match="idle_timeout"):
+            pipeline_factory(idle_timeout=0)
+
+    def test_idle_timeout_triggers_shutdown(self, pipeline_factory: PipelineFactory):
+        """Exceeding the idle timeout with no pending work sets the shutdown event."""
+        pipeline = pipeline_factory(idle_timeout=1)
+
+        pipeline._last_active = datetime.now() - timedelta(minutes=2)
+        pipeline._check_inactivity()
+
+        assert pipeline._shutdown_event.is_set()
+        assert pipeline._received_signal == signal.SIGTERM
+
+    def test_pending_work_resets_idle_clock(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """A staged but unfinished file counts as activity, deferring shutdown."""
+        pipeline = pipeline_factory(idle_timeout=1)
+        start_fake_tasks(pipeline)
+
+        (input_dir / "a.txt").write_text("payload")
+        pipeline._run_tracking_cycle()  # Stages the file; it has no output yet
+
+        pipeline._last_active = datetime.now() - timedelta(minutes=2)
+        pipeline._check_inactivity()
+
+        assert not pipeline._shutdown_event.is_set(), (
+            "Pending work should reset the idle clock"
+        )
+
+    @pytest.mark.xfail(
+        reason="Failure counts are per task while the input count holds each "
+        "file once, so a file failing in two fan-out tasks is counted twice "
+        "and the idle check believes the run is done",
+        strict=True,
+    )
+    def test_fan_out_failures_do_not_cut_the_run_short(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """Failing in two tasks must count as one failed file, not two.
+
+        Two of three files fail, each in both tasks. That produces four `.err`
+        files for two bad inputs, so the pipeline counts 4 accounted-for files
+        against 3 real ones while the third is still staged and healthy.
+        Believing the run is done, `_check_inactivity` skips its reset of the
+        idle clock and shutdown proceeds with work still in flight.
+
+        Same unit mismatch as `test_staged_discounts_each_failed_file_once` in
+        test_file_staging.py, which explains it in full.
+        """
+        pipeline = pipeline_factory(
+            [task_spec("alpha"), task_spec("beta")], idle_timeout=1
+        )
+        start_fake_tasks(pipeline)
+
+        for name in ("f0", "f1", "f2"):
+            (input_dir / f"{name}.txt").write_text("payload")
+        pipeline._run_tracking_cycle()
+
+        alpha, beta = pipeline._config.tasks
+        for name in ("f0", "f1"):
+            (alpha.output_dir / f"{name}.err").write_text("boom")
+            (beta.output_dir / f"{name}.err").write_text("boom")
+        pipeline._run_tracking_cycle()
+
+        assert (pipeline._symlinks_dir / "f2.txt").exists(), "f2 should still be staged"
+
+        pipeline._last_active = datetime.now() - timedelta(minutes=2)
+        pipeline._check_inactivity()
+
+        assert not pipeline._shutdown_event.is_set(), (
+            "A staged file is still in flight, so the run must not be idle"
+        )
+
+
+class TestShutdown:
+    """`run()` shutdown path: task termination, PID file, and exit code."""
+
+    def test_exits_with_signal_code(self, pipeline_factory: PipelineFactory):
+        """Shutdown from a signal exits with 128 + signum."""
+        pipeline = pipeline_factory()
+        pipeline._shutdown_event.set()  # Exit the loop on the first check
+        pipeline._received_signal = signal.SIGTERM
+
+        with pytest.raises(SystemExit) as exc_info:
+            pipeline.run()
+
+        assert exc_info.value.code == 128 + signal.SIGTERM
+
+    def test_clean_shutdown_does_not_exit(self, pipeline_factory: PipelineFactory):
+        """Without a signal, `run()` returns normally instead of calling sys.exit."""
+        pipeline = pipeline_factory()
+        pipeline._shutdown_event.set()
+
+        pipeline.run()
+
+    def test_terminates_running_tasks(
+        self,
+        pipeline_factory: PipelineFactory,
+        fake_popen: list[FakePopen],
+        stop_after_one_cycle: Callable[[Pipeline], None],
+    ):
+        """Live local tasks are terminated during shutdown."""
+        pipeline = pipeline_factory()
+        stop_after_one_cycle(pipeline)
+
+        pipeline.run()
+
+        assert len(fake_popen) == 1
+        assert fake_popen[0].terminate_calls == 1
+
+    @pytest.mark.xfail(
+        reason="Tasks started but never polled stay INACTIVE, so the shutdown "
+        "guard skips terminate() and leaks the subprocess. The test also pins "
+        "that no tracking cycle runs, so both must hold before this marker goes",
+        strict=True,
+    )
+    def test_terminates_tasks_when_shutdown_precedes_first_poll(
+        self,
+        pipeline_factory: PipelineFactory,
+        fake_popen: list[FakePopen],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Tasks must be terminated even if shutdown arrives before any status poll.
+
+        `run()` checks the shutdown event before its first cycle, so a signal
+        delivered between task startup and that check skips the cycle entirely
+        and no task is ever polled.
+
+        Two tasks, because the factory default is a single task and asserting
+        over one process would not catch a guard that skips the rest.
+        """
+        pipeline = pipeline_factory([task_spec("first"), task_spec("second")])
+        pipeline._shutdown_event.set()  # Signal arrives before the loop runs
+
+        cycles = 0
+
+        def count_cycle():
+            nonlocal cycles
+            cycles += 1
+
+        monkeypatch.setattr(pipeline, "_run_tracking_cycle", count_cycle)
+
+        pipeline.run()
+
+        assert [process.terminate_calls for process in fake_popen] == [1, 1]
+        # If a cycle ran, it would mark tasks alive and terminate them for the
+        # wrong reason, so pin that the shutdown path alone did the cleanup.
+        assert cycles == 0
+
+    def test_pid_file_removed_on_shutdown(
+        self,
+        pipeline_factory: PipelineFactory,
+        tmp_path: Path,
+    ):
+        """The PID file is removed when `run()` exits.
+
+        Setting the shutdown event up front skips the tracking loop but not
+        the PID write, which happens before the `try`, so there is a real
+        file for the `finally` to remove.
+        """
+        pid_file = tmp_path / "run.pid"
+        pipeline = pipeline_factory(pid_file=pid_file)
+        pipeline._shutdown_event.set()
+
+        pipeline.run()
+
+        assert not pid_file.exists()
+
+    def test_log_file_created(self, pipeline_factory: PipelineFactory):
+        """`run()` adds a file sink so the run is recorded in run.log."""
+        pipeline = pipeline_factory()
+        pipeline._shutdown_event.set()
+
+        pipeline.run()
+
+        assert (pipeline._internal_dir / "run.log").exists()
+
+    def test_signal_handler_requests_shutdown(self, pipeline_factory: PipelineFactory):
+        """The handler records the signal and sets the shutdown event."""
+        pipeline = pipeline_factory()
+
+        pipeline._signal_handler(signal.SIGINT, None)
+
+        assert pipeline._shutdown_event.is_set()
+        assert pipeline._received_signal == signal.SIGINT

--- a/tests/integration/pipeline/test_multi_task.py
+++ b/tests/integration/pipeline/test_multi_task.py
@@ -1,0 +1,238 @@
+"""Tests for pipelines with more than one task.
+
+Each task feeds the next along a dependency chain, and a file is completed
+only once every terminal task has finished with it.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from .helpers import PipelineFactory, stage_file, task_spec, write_output
+
+CHAIN = [
+    task_spec("first"),
+    task_spec("second", depends_on="first"),
+]
+
+MIXED_EXT_CHAIN = [
+    task_spec("first", input_ext=".txt", output_ext=".json"),
+    task_spec("second", depends_on="first", input_ext=".json", output_ext=".csv"),
+]
+
+FAN_OUT = [
+    task_spec("root"),
+    task_spec("leafA", depends_on="root"),
+    task_spec("leafB", depends_on="root"),
+]
+
+
+class TestTaskWiring:
+    """Task directories follow the dependency graph."""
+
+    def test_chain_wires_output_to_next_input(self, pipeline_factory: PipelineFactory):
+        """A dependent task reads from its parent's output directory."""
+        pipeline = pipeline_factory(CHAIN)
+        first, second = pipeline._config.tasks
+
+        assert first.input_dir == pipeline._symlinks_dir
+        assert second.input_dir == first.output_dir
+
+    def test_terminal_tasks_identified(self, pipeline_factory: PipelineFactory):
+        """Only tasks nothing depends on count as terminal."""
+        pipeline = pipeline_factory(FAN_OUT)
+
+        terminal = {t.name for t in pipeline._config.terminal_tasks}
+        assert terminal == {"leafA", "leafB"}
+
+
+class TestChainCompletion:
+    """A file is completed only after the final task in a chain finishes."""
+
+    def test_not_finished_until_last_task(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """Output from an intermediate task alone does not complete the file."""
+        pipeline = pipeline_factory(CHAIN)
+
+        stage_file(pipeline, input_dir, "a")
+
+        write_output(pipeline, "a", task="first")
+        pipeline._handle_processed_files()
+
+        assert not (pipeline._finished_dir / "a.txt").exists(), (
+            "Only the terminal task's output should complete a file"
+        )
+
+        write_output(pipeline, "a", task="second")
+        pipeline._handle_processed_files()
+
+        assert (pipeline._finished_dir / "a.txt").exists()
+
+    def test_intermediate_output_cleaned(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """Completing a chain removes intermediate outputs as well."""
+        pipeline = pipeline_factory(CHAIN)
+        first, second = pipeline._config.tasks
+
+        stage_file(pipeline, input_dir, "a")
+
+        write_output(pipeline, "a", task="first")
+        pipeline._handle_processed_files()
+        write_output(pipeline, "a", task="second")
+        pipeline._handle_processed_files()
+
+        assert not (first.output_dir / "a.txt").exists()
+        assert not (second.output_dir / "a.txt").exists()
+
+
+class TestMixedExtensionChain:
+    """A chain that changes extension at every step.
+
+    Completion is keyed off the terminal task's `output_ext`, while the
+    finished marker and symlink keep the root `input_ext`.
+    """
+
+    def test_completes_on_terminal_ext(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """Only the terminal `.csv` output completes a `.txt` input."""
+        pipeline = pipeline_factory(MIXED_EXT_CHAIN)
+
+        stage_file(pipeline, input_dir, "a")
+
+        write_output(pipeline, "a", task="first")
+        pipeline._handle_processed_files()
+
+        assert not (pipeline._finished_dir / "a.txt").exists()
+
+        write_output(pipeline, "a", task="second")
+        pipeline._handle_processed_files()
+
+        assert (pipeline._finished_dir / "a.txt").exists()
+        assert not (pipeline._symlinks_dir / "a.txt").exists()
+
+    def test_intermediate_outputs_cleaned_at_own_ext(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """Each task's output is removed under that task's own extension."""
+        pipeline = pipeline_factory(MIXED_EXT_CHAIN)
+        first, second = pipeline._config.tasks
+
+        stage_file(pipeline, input_dir, "a")
+
+        write_output(pipeline, "a", task="first")
+        pipeline._handle_processed_files()
+        write_output(pipeline, "a", task="second")
+        pipeline._handle_processed_files()
+
+        assert not (first.output_dir / "a.json").exists()
+        assert not (second.output_dir / "a.csv").exists()
+
+
+class TestFilenameHandling:
+    """File IDs are derived by stripping extensions, not by splitting on dots."""
+
+    def test_multi_dot_filename_completes(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """A name containing extra dots survives ID derivation across a chain."""
+        pipeline = pipeline_factory(CHAIN)
+        filename = "data.v2.txt"
+
+        stage_file(pipeline, input_dir, "data.v2")
+
+        assert (pipeline._symlinks_dir / filename).is_symlink()
+
+        write_output(pipeline, "data.v2", task="first")
+        pipeline._handle_processed_files()
+        write_output(pipeline, "data.v2", task="second")
+        pipeline._handle_processed_files()
+
+        assert (pipeline._finished_dir / filename).exists()
+        assert not (pipeline._symlinks_dir / filename).exists()
+
+
+class TestFanOutCompletion:
+    """Every terminal task must finish before a file is completed."""
+
+    def test_one_terminal_task_is_not_enough(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """A file is not completed while a sibling terminal task is outstanding."""
+        pipeline = pipeline_factory(FAN_OUT)
+
+        stage_file(pipeline, input_dir, "a")
+
+        write_output(pipeline, "a", task="leafA")
+        pipeline._handle_processed_files()
+
+        assert not (pipeline._finished_dir / "a.txt").exists()
+
+    def test_finishes_when_terminal_tasks_agree_in_one_cycle(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """Both terminal outputs present in the same cycle complete the file."""
+        pipeline = pipeline_factory(FAN_OUT)
+
+        stage_file(pipeline, input_dir, "a")
+
+        write_output(pipeline, "a", task="leafA")
+        write_output(pipeline, "a", task="leafB")
+        pipeline._handle_processed_files()
+
+        assert (pipeline._finished_dir / "a.txt").exists()
+        assert not (pipeline._symlinks_dir / "a.txt").exists()
+
+    @pytest.mark.xfail(
+        reason="Completion intersects only files seen in the current cycle, so a "
+        "terminal task recorded in an earlier cycle drops out and the file is "
+        "never completed",
+        strict=True,
+    )
+    def test_finishes_when_terminal_tasks_finish_on_different_cycles(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """Terminal tasks finishing at different times must still complete the file.
+
+        Sibling tasks rarely finish within the same polling cycle, so this is
+        the ordinary case rather than an edge case.
+        """
+        pipeline = pipeline_factory(FAN_OUT)
+
+        stage_file(pipeline, input_dir, "a")
+
+        write_output(pipeline, "a", task="leafA")
+        pipeline._handle_processed_files()
+
+        write_output(pipeline, "a", task="leafB")
+        pipeline._handle_processed_files()
+
+        assert (pipeline._finished_dir / "a.txt").exists(), (
+            "File should be completed once every terminal task has finished"
+        )
+
+    @pytest.mark.xfail(
+        reason="Same root cause as staggered completion: the file is never "
+        "completed, so its staged symlink and task outputs are never cleaned up",
+        strict=True,
+    )
+    def test_staggered_completion_does_not_leak(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """A staggered fan-out must not strand its symlink and outputs."""
+        pipeline = pipeline_factory(FAN_OUT)
+
+        stage_file(pipeline, input_dir, "a")
+
+        write_output(pipeline, "a", task="leafA")
+        pipeline._handle_processed_files()
+
+        write_output(pipeline, "a", task="leafB")
+        pipeline._handle_processed_files()
+
+        assert not (pipeline._symlinks_dir / "a.txt").exists()
+        for name in ("leafA", "leafB"):
+            task = next(t for t in pipeline._config.tasks if t.name == name)
+            assert not (task.output_dir / "a.txt").exists()

--- a/tests/integration/pipeline/test_task_supervision.py
+++ b/tests/integration/pipeline/test_task_supervision.py
@@ -1,0 +1,161 @@
+"""Tests for how Pipeline watches running tasks and reacts to their state.
+
+Local tasks are watched through their subprocess exit code; Slurm tasks
+through squeue. Slurm jobs that hit their wall-clock limit are resubmitted so
+long pipelines survive time limits.
+"""
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from tigerflow.models import SlurmTaskConfig, TaskStatus, TaskStatusKind
+from tigerflow.pipeline import Pipeline
+
+from .helpers import FakePopen, PipelineFactory, task_spec
+
+SLURM_TASK = task_spec(
+    "gpu",
+    kind="slurm",
+    max_workers=2,
+    worker_resources={"cpus": 1, "memory": "4G", "time": "01:00:00"},
+)
+
+
+def slurm_status(kind: TaskStatusKind, detail: str | None = None) -> TaskStatus:
+    return TaskStatus(kind=kind, detail=detail)
+
+
+class TestSubprocessStatus:
+    """Local task health is derived from the subprocess exit code."""
+
+    def test_running_process_is_active(self):
+        """A process that has not exited reports ACTIVE."""
+        status = Pipeline._get_subprocess_status(FakePopen())
+
+        assert status.kind is TaskStatusKind.ACTIVE
+        assert status.is_alive
+
+    def test_exited_process_is_inactive_with_code(
+        self, pipeline_factory: PipelineFactory
+    ):
+        """An exited process reports INACTIVE and surfaces its exit code."""
+        pipeline = pipeline_factory()
+        process = FakePopen()
+        process.exit_code = 3
+
+        status = pipeline._get_subprocess_status(process)
+
+        assert status.kind is TaskStatusKind.INACTIVE
+        assert not status.is_alive
+        assert "3" in (status.detail or "")
+
+    def test_status_change_is_recorded(self, pipeline_factory: PipelineFactory):
+        """`_check_task_status` reflects a task that has died."""
+        pipeline = pipeline_factory()
+        process = FakePopen()
+        pipeline._subprocesses["echo"] = process
+
+        pipeline._check_task_status()
+        assert pipeline._task_status["echo"].is_alive
+
+        process.exit_code = 1
+        pipeline._check_task_status()
+
+        assert not pipeline._task_status["echo"].is_alive
+
+
+class TestSlurmTimeout:
+    """Slurm tasks that hit their time limit are resubmitted."""
+
+    def test_resubmits_after_timeout(self, pipeline_factory: PipelineFactory):
+        """A TIMEOUT status triggers a fresh submission and records the new ID."""
+        pipeline = pipeline_factory([SLURM_TASK])
+        pipeline._slurm_task_ids["gpu"] = 111
+        pipeline._task_status["gpu"] = slurm_status(TaskStatusKind.INACTIVE, "TIMEOUT")
+
+        with patch("tigerflow.pipeline.submit_to_slurm", return_value=222) as resubmit:
+            pipeline._handle_task_timeout()
+
+        resubmit.assert_called_once()
+        assert pipeline._slurm_task_ids["gpu"] == 222
+
+    def test_no_resubmit_while_running(self, pipeline_factory: PipelineFactory):
+        pipeline = pipeline_factory([SLURM_TASK])
+        pipeline._slurm_task_ids["gpu"] = 111
+        pipeline._task_status["gpu"] = slurm_status(TaskStatusKind.ACTIVE)
+
+        with patch("tigerflow.pipeline.submit_to_slurm") as resubmit:
+            pipeline._handle_task_timeout()
+
+        resubmit.assert_not_called()
+
+    # Slurm tasks start out INACTIVE with no detail, and sacct also returns
+    # no reason once a job ages out of accounting
+    @pytest.mark.parametrize("detail", ["FAILED", None])
+    def test_no_resubmit_on_other_failures(
+        self, pipeline_factory: PipelineFactory, detail: str | None
+    ):
+        """A task that died for a non-timeout reason is not resubmitted."""
+        pipeline = pipeline_factory([SLURM_TASK])
+        pipeline._slurm_task_ids["gpu"] = 111
+        pipeline._task_status["gpu"] = slurm_status(TaskStatusKind.INACTIVE, detail)
+
+        with patch("tigerflow.pipeline.submit_to_slurm") as resubmit:
+            pipeline._handle_task_timeout()
+
+        resubmit.assert_not_called()
+        assert pipeline._slurm_task_ids["gpu"] == 111
+
+    def test_resubmits_once_per_timeout(self, pipeline_factory: PipelineFactory):
+        """The replacement job ID is what the next status poll observes.
+
+        `_handle_task_timeout` records the new ID so the following cycle polls
+        the replacement; polling the dead job would keep reporting TIMEOUT and
+        resubmit on every cycle.
+        """
+        pipeline = pipeline_factory([SLURM_TASK])
+        pipeline._slurm_task_ids["gpu"] = 111
+
+        with (
+            patch("tigerflow.pipeline.submit_to_slurm", return_value=222) as resubmit,
+            patch(
+                "tigerflow.pipeline.get_slurm_task_status",
+                side_effect=[
+                    slurm_status(TaskStatusKind.INACTIVE, "Reason: TIMEOUT"),
+                    slurm_status(TaskStatusKind.PENDING, "Reason: Priority"),
+                ],
+            ) as poll,
+        ):
+            pipeline._run_tracking_cycle()
+            pipeline._run_tracking_cycle()
+
+        assert resubmit.call_count == 1, "Only the timed-out job should be resubmitted"
+        assert poll.call_args_list[1].args[0] == 222, "Second poll must use the new ID"
+
+
+class TestSlurmShutdown:
+    """Slurm jobs are cancelled when the pipeline shuts down."""
+
+    def test_scancel_issued_for_worker_and_client(
+        self, pipeline_factory: PipelineFactory
+    ):
+        """Shutdown cancels both the worker and client jobs by name."""
+        pipeline = pipeline_factory([SLURM_TASK])
+        pipeline._shutdown_event.set()
+
+        task = pipeline._config.tasks[0]
+        assert isinstance(task, SlurmTaskConfig)  # Narrow for the type checker
+
+        with (
+            patch("tigerflow.pipeline.submit_to_slurm", return_value=111),
+            patch.object(subprocess, "run") as run,
+        ):
+            pipeline.run()
+
+        # Ignore kwargs so adding e.g. `check=True` does not fail the test;
+        # the argv itself is the contract with the scancel binary
+        cancel_argv = [call.args[0] for call in run.call_args_list if call.args]
+        assert ["scancel", "-n", task.worker_job_name] in cancel_argv
+        assert ["scancel", "-n", task.client_job_name] in cancel_argv


### PR DESCRIPTION
## Summary

- Add an integration suite for `Pipeline` — init cleanup, staging, task supervision, shutdown, and multi-task fan-out. Tests run in-process against real temp directories and fake only task subprocesses.
- Extract the tracking-loop body into `_run_tracking_cycle()` so tests can drive one cycle without waiting on the poll interval. No behavior change; the docstring records why `_check_task_status` must precede `_handle_task_timeout`.
- Pin four bugs the suite found with `strict=True` xfail, so each fails CI once fixed rather than being skipped:
  - Fan-out failures are double-counted, ending runs early (2 tests)
  - Files completing across separate cycles are never completed or cleaned up (2 tests)
  - Bad middleware output kills the tracking loop
  - Shutdown before the first poll leaks task subprocesses