### PR TITLE
Fix inflated failed-file counts when a file fails in multiple tasks

### DIFF
--- a/docs/mkdocs/guides/pipeline.md
+++ b/docs/mkdocs/guides/pipeline.md
@@ -200,14 +200,16 @@ def my_filter(candidates: list[Path], context: StagingContext) -> list[Path]:
     return candidates
 ```
 
-The `StagingContext` provides a read-only view of the current pipeline state:
+The `StagingContext` provides a read-only view of the current pipeline state. The
+four counts partition input files by state, so each file is counted in exactly one
+of them --- a file that failed in several tasks still counts once:
 
 | Field | Type | Description |
 | ----- | ---- | ----------- |
 | `waiting` | `int` | Files in the input directory not yet staged |
-| `staged` | `int` | Files staged but not yet completed |
+| `staged` | `int` | Files staged and still live (failures excluded) |
 | `completed` | `int` | Files that have finished all tasks |
-| `failed` | `int` | Total error files across all tasks |
+| `failed` | `int` | Files that failed in at least one task |
 | `input_dir` | `Path` | The pipeline's input directory |
 | `output_dir` | `Path` | The pipeline's output directory |
 

--- a/src/tigerflow/pipeline.py
+++ b/src/tigerflow/pipeline.py
@@ -245,9 +245,15 @@ class Pipeline:
 
     def _build_staging_context(self) -> StagingContext:
         """Build the current context for staging middleware."""
+        failed_stems = self._failed_stems()
+
         n_finished = sum(1 for f in self._finished_dir.iterdir() if f.is_file())
-        n_failed = sum(len(e) for e in self._task_error_filenames.values())
-        n_staged = sum(1 for f in self._symlinks_dir.iterdir() if f.is_file())
+        n_staged = sum(
+            1
+            for f in self._symlinks_dir.iterdir()
+            if f.is_file()
+            and f.name.removesuffix(self._config.root_input_ext) not in failed_stems
+        )
         n_waiting = sum(
             1
             for f in self._input_dir.iterdir()
@@ -255,11 +261,12 @@ class Pipeline:
             and f.name.endswith(self._config.root_input_ext)
             and f.name not in self._filenames
         )
+
         return StagingContext(
             waiting=n_waiting,
-            staged=n_staged - n_failed,
+            staged=n_staged,
             completed=n_finished,
-            failed=n_failed,
+            failed=len(failed_stems),
             input_dir=self._input_dir,
             output_dir=self._output_dir,
         )
@@ -333,6 +340,18 @@ class Pipeline:
             if n_files > 0:
                 logger.error("[{}] {} failed files", task.name, n_files)
 
+    def _failed_stems(self) -> set[str]:
+        """Stems of input files that failed in at least one task.
+
+        A file failing in several tasks leaves one error file per task, so
+        stems are unioned to count that file once.
+        """
+        return {
+            filename.removesuffix(".err")
+            for filenames in self._task_error_filenames.values()
+            for filename in filenames
+        }
+
     def _handle_processed_files(self):
         # Identify *newly* processed files for each task
         processed_filenames_by_task: dict[str, set[str]] = {
@@ -381,14 +400,12 @@ class Pipeline:
         if completed_file_ids:
             logger.info("Completed processing {} files", len(completed_file_ids))
             n_finished = sum(1 for f in self._finished_dir.iterdir() if f.is_file())
-            n_failed = sum(len(errs) for errs in self._task_error_filenames.values())
-            if (n_finished + n_failed) >= len(self._filenames):
+            if (n_finished + len(self._failed_stems())) >= len(self._filenames):
                 logger.info("No more files to process, starting idle time count")
 
     def _check_inactivity(self):
         n_finished = sum(1 for file in self._finished_dir.iterdir() if file.is_file())
-        n_failed = sum(len(errs) for errs in self._task_error_filenames.values())
-        if (n_finished + n_failed) < len(self._filenames):  # Still in progress
+        if (n_finished + len(self._failed_stems())) < len(self._filenames):
             self._last_active = datetime.now()
 
         inactivity = datetime.now() - self._last_active

--- a/src/tigerflow/staging.py
+++ b/src/tigerflow/staging.py
@@ -17,12 +17,16 @@ from tigerflow.utils import (
 
 @dataclass(frozen=True)
 class StagingContext:
-    """Read-only view of pipeline state for staging middleware."""
+    """Read-only view of pipeline state for staging middleware.
+
+    The four counts partition input files by state, so each file is counted
+    in exactly one of them.
+    """
 
     waiting: int  # Files in input_dir not yet staged
-    staged: int  # Files staged but not completed
+    staged: int  # Files staged and still live (failures excluded)
     completed: int  # Files in .finished directory
-    failed: int  # Total error files across tasks
+    failed: int  # Files that failed in at least one task
     input_dir: Path  # Reference for companion lookups
     output_dir: Path  # Reference for capacity checks
 

--- a/tests/integration/pipeline/test_file_staging.py
+++ b/tests/integration/pipeline/test_file_staging.py
@@ -224,10 +224,10 @@ class TestStagingContext:
         The tests above each set up one state at a time, so this is the only
         place `waiting`, `staged`, `completed`, and `failed` are all pinned
         against each other. Four files are staged, one completes, one fails:
-        completion removes a symlink and failure does not, so `staged` is 3
-        symlinks minus 1 recorded failure. The counts are deliberately unequal
-        because one file per state lets several wrong formulas land on the
-        right answer.
+        completion removes a symlink and failure does not, so `staged` counts
+        the 3 remaining symlinks excluding the file that failed. The counts are
+        deliberately unequal because one file per state lets several wrong
+        formulas land on the right answer.
         """
         pipeline = pipeline_factory()
         for i in range(4):
@@ -245,13 +245,7 @@ class TestStagingContext:
         counts = (context.waiting, context.staged, context.completed, context.failed)
         assert counts == (0, 2, 1, 1)
 
-    @pytest.mark.xfail(
-        reason="Failures are subtracted as a per-task total, so a file failing "
-        "in two fan-out tasks is discounted twice and staged undercounts the "
-        "files still live",
-        strict=True,
-    )
-    def test_staged_discounts_each_failed_file_once(
+    def test_fan_out_failure_counts_one_file(
         self, pipeline_factory: PipelineFactory, input_dir: Path
     ):
         """A file failing in several tasks must free one staging slot, not one per task.
@@ -261,21 +255,14 @@ class TestStagingContext:
         because the other tasks read the same directory, so `staged` cannot
         simply be the symlink count.
 
-        The defect is that the exclusion mixes two units. `_build_staging_context`
-        subtracts `failed`, which counts error *files* across tasks, from a
-        symlink count that holds each input *file* once.
-
         Here two files are staged under a cap of 2, and one of them fails in
         `alpha` and `beta` while `gamma` has not processed it yet. The untouched
         file still holds a slot and the failed one frees a single slot however
-        many tasks recorded it, so `staged` should be 1, but 2 - 2 reports 0.
-
-        Note that `failed` reading 2 for one bad input is not itself the bug.
-        It is documented as a count of error files, so 2 is what it should
-        report. Only the subtraction is wrong.
+        many tasks recorded it, so `staged` is 1 and `failed` is 1 even though
+        two error files exist.
 
         `test_fan_out_failures_do_not_cut_the_run_short` in test_lifecycle.py
-        covers the other symptom of this mismatch.
+        pins the same rule for the idle check.
         """
         pipeline = pipeline_factory(
             [task_spec("alpha"), task_spec("beta"), task_spec("gamma")],
@@ -287,7 +274,7 @@ class TestStagingContext:
 
         pipeline._stage_new_files()
         staged = [f.name for f in pipeline._symlinks_dir.iterdir()]
-        assert len(staged) == 2, "Cap should admit exactly 2 on the first pass"
+        assert len(staged) == 2
 
         failed_name = staged[0]
         failed_stem = Path(failed_name).stem
@@ -299,11 +286,34 @@ class TestStagingContext:
             "Failure must not remove the symlink the remaining task reads from"
         )
 
-        assert pipeline._build_staging_context().staged == 1, (
-            "One of the 2 staged files is untouched and the other can no longer "
-            "complete, so one slot is occupied no matter how many tasks recorded "
-            "the failure"
+        context = pipeline._build_staging_context()
+        assert (context.staged, context.failed) == (1, 1)
+
+    def test_failed_file_excluded_under_multi_part_extension(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """Failed stems must match symlink stems when the input extension has two parts.
+
+        Workers name error files by stripping the whole `output_ext`, so a
+        `.fastq.gz` input fails to `sample.err`. The symlink stem must therefore
+        be derived by stripping the whole `root_input_ext` as well. `Path.stem`
+        would drop only `.gz` and yield `sample.fastq`, which never matches,
+        silently leaving the failed file counted as staged.
+        """
+        pipeline = pipeline_factory(
+            [task_spec(input_ext=".fastq.gz", output_ext=".fastq.gz")]
         )
+        assert pipeline._config.root_input_ext == ".fastq.gz"
+
+        (input_dir / "sample.fastq.gz").write_text("x")
+        pipeline._stage_new_files()
+
+        task = pipeline._config.tasks[0]
+        (task.output_dir / "sample.err").write_text("boom")
+        pipeline._report_failed_files()
+
+        context = pipeline._build_staging_context()
+        assert (context.staged, context.failed) == (0, 1)
 
 
 class TestFailureReporting:

--- a/tests/integration/pipeline/test_lifecycle.py
+++ b/tests/integration/pipeline/test_lifecycle.py
@@ -146,25 +146,19 @@ class TestInactivity:
             "Pending work should reset the idle clock"
         )
 
-    @pytest.mark.xfail(
-        reason="Failure counts are per task while the input count holds each "
-        "file once, so a file failing in two fan-out tasks is counted twice "
-        "and the idle check believes the run is done",
-        strict=True,
-    )
     def test_fan_out_failures_do_not_cut_the_run_short(
         self, pipeline_factory: PipelineFactory, input_dir: Path
     ):
         """Failing in two tasks must count as one failed file, not two.
 
         Two of three files fail, each in both tasks. That produces four `.err`
-        files for two bad inputs, so the pipeline counts 4 accounted-for files
-        against 3 real ones while the third is still staged and healthy.
-        Believing the run is done, `_check_inactivity` skips its reset of the
-        idle clock and shutdown proceeds with work still in flight.
+        files for two bad inputs, so counting error files would account for 4
+        against 3 real inputs while the third is still staged and healthy.
+        `_check_inactivity` would then believe the run is done, skip its reset
+        of the idle clock, and shut down with work still in flight.
 
-        Same unit mismatch as `test_staged_discounts_each_failed_file_once` in
-        test_file_staging.py, which explains it in full.
+        `test_fan_out_failure_counts_one_file` in test_file_staging.py
+        pins the same rule for the staging count.
         """
         pipeline = pipeline_factory(
             [task_spec("alpha"), task_spec("beta")], idle_timeout=1


### PR DESCRIPTION
## Summary

- A file failing in several tasks leaves one error file per task, so summing per-task error counts double-counted it. `StagingContext.failed` now counts distinct files.
- `staged` is now derived by excluding failed files directly, instead of subtracting the inflated total — which could go negative and starve staging middleware.
- The idle/inactivity checks use the same count, so the pipeline no longer declares "no more files to process" early.
- Docs and field comments now state that the four counts partition input files into disjoint states.
