### PR TITLE
Fix task cleanup gaps in pipeline shutdown

### DIFF
--- a/docs/mkdocs/guides/configuration.md
+++ b/docs/mkdocs/guides/configuration.md
@@ -32,6 +32,7 @@ export TIGERFLOW_ENV_FILE=/path/to/custom.env
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `TIGERFLOW_PIPELINE_POLL_INTERVAL` | `10` | Pipeline polling interval in seconds |
+| `TIGERFLOW_PIPELINE_SHUTDOWN_TIMEOUT` | `30` | Timeout in seconds to wait for tasks to exit during shutdown |
 | `TIGERFLOW_TASK_POLL_INTERVAL` | `3` | Task polling interval in seconds |
 | `TIGERFLOW_SLURM_TASK_CLIENT_HOURS` | `24` | Time limit in hours for each Slurm task client job (respawns when expired) |
 | `TIGERFLOW_SLURM_TASK_SCALE_INTERVAL` | `15` | Interval in seconds between Slurm task scaling checks |

--- a/src/tigerflow/pipeline.py
+++ b/src/tigerflow/pipeline.py
@@ -190,7 +190,7 @@ class Pipeline:
             self._handle_processed_files()
             logger.info("Shutting down pipeline")
             for name, process in self._subprocesses.items():
-                if self._task_status[name].is_alive:
+                if process.poll() is None:
                     logger.info("[{}] Terminating...", name)
                     process.terminate()
             for task in self._config.tasks:
@@ -199,9 +199,7 @@ class Pipeline:
                 logger.info("[{}] Terminating...", task.name)
                 subprocess.run(["scancel", "-n", task.worker_job_name])
                 subprocess.run(["scancel", "-n", task.client_job_name])
-            while any(status.is_alive for status in self._task_status.values()):
-                self._check_task_status()
-                time.sleep(1)
+            self._drain_tasks()
             logger.info("Pipeline shutdown complete")
             if self._pid_file is not None:
                 self._pid_file.unlink(missing_ok=True)
@@ -235,10 +233,12 @@ class Pipeline:
             if isinstance(task, (LocalTaskConfig, LocalAsyncTaskConfig)):
                 process = subprocess.Popen(["bash", "-c", script])
                 self._subprocesses[task.name] = process
+                self._task_status[task.name] = TaskStatus(kind=TaskStatusKind.ACTIVE)
                 logger.info("[{}] Started with PID {}", task.name, process.pid)
             elif isinstance(task, SlurmTaskConfig):
                 job_id = submit_to_slurm(script)
                 self._slurm_task_ids[task.name] = job_id
+                self._task_status[task.name] = TaskStatus(kind=TaskStatusKind.PENDING)
                 logger.info("[{}] Submitted with Slurm job ID {}", task.name, job_id)
             else:
                 raise ValueError(f"Unsupported task kind: {type(task)}")
@@ -280,6 +280,13 @@ class Pipeline:
 
     def _check_task_status(self):
         for task in self._config.tasks:
+            # `_start_tasks` may fail partway, leaving later tasks unstarted; polling
+            # one of those would raise inside the shutdown path and mask the real error
+            if (
+                task.name not in self._subprocesses
+                and task.name not in self._slurm_task_ids
+            ):
+                continue
             if isinstance(task, (LocalTaskConfig, LocalAsyncTaskConfig)):
                 process = self._subprocesses[task.name]
                 status = self._get_subprocess_status(process)
@@ -301,6 +308,29 @@ class Pipeline:
                     status.kind.name,
                     f" ({status.detail})" if status.detail else "",
                 )
+
+    def _drain_tasks(self):
+        """Wait for terminated tasks to actually exit, both local and Slurm.
+
+        The wait is bounded because SIGTERM is a request a task may ignore, and
+        this loop does not check the shutdown event, so a second Ctrl-C could not
+        break out of an unbounded one. On expiry local processes escalate to
+        SIGKILL; Slurm jobs get no equivalent, as `scancel` sends its own SIGKILL
+        follow-up.
+        """
+        deadline = time.monotonic() + settings.pipeline_shutdown_timeout
+        while True:
+            self._check_task_status()
+            if not any(status.is_alive for status in self._task_status.values()):
+                return
+            if time.monotonic() >= deadline:
+                for name, process in self._subprocesses.items():
+                    if process.poll() is None:
+                        logger.warning("[{}] Did not exit in time, killing", name)
+                        process.kill()
+                logger.warning("Shutdown timed out, stopped waiting for tasks")
+                return
+            time.sleep(1)
 
     def _handle_task_timeout(self):
         for task in self._config.tasks:

--- a/src/tigerflow/settings.py
+++ b/src/tigerflow/settings.py
@@ -20,6 +20,12 @@ class TigerflowSettings(BaseSettings):
         description="Pipeline polling interval in seconds",
     )
 
+    pipeline_shutdown_timeout: int = Field(
+        default=30,
+        gt=0,
+        description="Timeout in seconds to wait for tasks to exit during shutdown",
+    )
+
     task_poll_interval: int = Field(
         default=3,
         gt=0,

--- a/tests/integration/pipeline/helpers.py
+++ b/tests/integration/pipeline/helpers.py
@@ -54,7 +54,8 @@ class FakePopen(subprocess.Popen):
     read, so anything Pipeline reaches for beyond `poll`/`terminate`/`pid`
     raises AttributeError instead of acting on a pid that is not ours.
 
-    Set `exit_code` to make a task look like it died.
+    Set `exit_code` to make a task look like it died. Set `ignores_terminate` to
+    model a task that does not honor SIGTERM, which only `kill` then stops.
     """
 
     def __init__(self, *args, **kwargs):
@@ -64,6 +65,8 @@ class FakePopen(subprocess.Popen):
         self.pid = 424242
         self.exit_code: int | None = None
         self.terminate_calls = 0
+        self.kill_calls = 0
+        self.ignores_terminate = False
 
     def poll(self) -> int | None:
         return self.exit_code
@@ -72,16 +75,20 @@ class FakePopen(subprocess.Popen):
         self.terminate_calls += 1
         # A terminated process must stop reporting itself as alive, otherwise
         # the shutdown loop in Pipeline.run() never exits
-        if self.exit_code is None:
+        if self.exit_code is None and not self.ignores_terminate:
             self.exit_code = -15
+
+    def kill(self):
+        self.kill_calls += 1
+        if self.exit_code is None:
+            self.exit_code = -9
 
 
 def start_fake_tasks(pipeline: Pipeline) -> None:
     """Register a fake subprocess per task so a cycle can poll task status.
 
     `_check_task_status()` looks tasks up in `_subprocesses`, which only
-    `_start_tasks()` fills — and tests driving cycles never call it. Status is
-    set separately because the constructor starts tasks INACTIVE.
+    `_start_tasks()` fills — and tests driving cycles never call it.
     """
     for task in pipeline._config.tasks:
         pipeline._subprocesses[task.name] = FakePopen()

--- a/tests/integration/pipeline/test_lifecycle.py
+++ b/tests/integration/pipeline/test_lifecycle.py
@@ -10,12 +10,14 @@ pass ahead of the same number of bare cycle calls.
 """
 
 import signal
+import subprocess
 from collections.abc import Callable
 from datetime import datetime, timedelta
 from pathlib import Path
 
 import pytest
 
+from tigerflow.models import TaskStatus, TaskStatusKind
 from tigerflow.pipeline import Pipeline
 
 from .helpers import (
@@ -227,23 +229,16 @@ class TestShutdown:
         assert len(fake_popen) == 1
         assert fake_popen[0].terminate_calls == 1
 
-    @pytest.mark.xfail(
-        reason="Tasks started but never polled stay INACTIVE, so the shutdown "
-        "guard skips terminate() and leaks the subprocess. The test also pins "
-        "that no tracking cycle runs, so both must hold before this marker goes",
-        strict=True,
-    )
-    def test_terminates_tasks_when_shutdown_precedes_first_poll(
+    def test_terminates_tasks_when_shutdown_precedes_first_cycle(
         self,
         pipeline_factory: PipelineFactory,
         fake_popen: list[FakePopen],
         monkeypatch: pytest.MonkeyPatch,
     ):
-        """Tasks must be terminated even if shutdown arrives before any status poll.
+        """Tasks started but never tracked must still be terminated.
 
         `run()` checks the shutdown event before its first cycle, so a signal
-        delivered between task startup and that check skips the cycle entirely
-        and no task is ever polled.
+        delivered between task startup and that check skips the cycle entirely.
 
         Two tasks, because the factory default is a single task and asserting
         over one process would not catch a guard that skips the rest.
@@ -262,9 +257,95 @@ class TestShutdown:
         pipeline.run()
 
         assert [process.terminate_calls for process in fake_popen] == [1, 1]
-        # If a cycle ran, it would mark tasks alive and terminate them for the
-        # wrong reason, so pin that the shutdown path alone did the cleanup.
+        # Pin that the shutdown path alone did the cleanup, with no cycle
+        # having run to reach the tasks first.
         assert cycles == 0
+
+    def test_terminates_task_whose_status_is_stale(
+        self,
+        pipeline_factory: PipelineFactory,
+        fake_popen: list[FakePopen],
+        stop_after_one_cycle: Callable[[Pipeline], None],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A running task is terminated even if its cached status says otherwise.
+
+        Status is a cache refreshed by polling, so termination asks the OS via
+        `poll()` instead. Other shutdown tests would pass even on the stale
+        cache, so this one falsifies it deliberately.
+        """
+        pipeline = pipeline_factory()
+        stop_after_one_cycle(pipeline)
+
+        original_check = pipeline._check_task_status
+
+        def check_then_falsify():
+            original_check()
+            for name in pipeline._task_status:
+                pipeline._task_status[name] = TaskStatus(kind=TaskStatusKind.INACTIVE)
+
+        monkeypatch.setattr(pipeline, "_check_task_status", check_then_falsify)
+
+        pipeline.run()
+
+        assert fake_popen[0].terminate_calls == 1
+
+    def test_kills_task_that_ignores_terminate(
+        self,
+        pipeline_factory: PipelineFactory,
+        fake_popen: list[FakePopen],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A task that does not honor SIGTERM is killed once the drain expires."""
+        # Expire the deadline on its first check, so the test does not wait it out
+        monkeypatch.setattr("tigerflow.pipeline.settings.pipeline_shutdown_timeout", 0)
+        pipeline = pipeline_factory()
+        pipeline._shutdown_event.set()
+
+        def ignore_terminate(*args, **kwargs) -> FakePopen:
+            process = FakePopen(*args, **kwargs)
+            process.ignores_terminate = True
+            fake_popen.append(process)
+            return process
+
+        monkeypatch.setattr(subprocess, "Popen", ignore_terminate)
+
+        pipeline.run()
+
+        assert fake_popen[0].terminate_calls == 1
+        assert fake_popen[0].kill_calls == 1
+
+    def test_partial_start_failure_propagates(
+        self,
+        pipeline_factory: PipelineFactory,
+        fake_popen: list[FakePopen],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """A task failing to start must not have its error masked by shutdown.
+
+        The first task is already running when the second fails, so shutdown
+        polls task status with the second task absent from `_subprocesses`.
+        """
+        pid_file = tmp_path / "run.pid"
+        pipeline = pipeline_factory(
+            [task_spec("first"), task_spec("second")], pid_file=pid_file
+        )
+
+        def fail_on_second(*args, **kwargs) -> FakePopen:
+            if fake_popen:  # The first task already spawned
+                raise OSError("cannot spawn")
+            process = FakePopen(*args, **kwargs)
+            fake_popen.append(process)
+            return process
+
+        monkeypatch.setattr(subprocess, "Popen", fail_on_second)
+
+        with pytest.raises(OSError, match="cannot spawn"):
+            pipeline.run()
+
+        assert fake_popen[0].terminate_calls == 1
+        assert not pid_file.exists()
 
     def test_pid_file_removed_on_shutdown(
         self,

--- a/tests/integration/pipeline/test_task_supervision.py
+++ b/tests/integration/pipeline/test_task_supervision.py
@@ -138,6 +138,16 @@ class TestSlurmTimeout:
 class TestSlurmShutdown:
     """Slurm jobs are cancelled when the pipeline shuts down."""
 
+    @staticmethod
+    def _no_such_job(argv, *args, **kwargs) -> subprocess.CompletedProcess:
+        """Stand in for `subprocess.run` with output that reads as a finished job.
+
+        Empty stdout is what `get_slurm_task_status` treats as gone. A bare mock
+        returns a mock from `.stdout`, which reads as live instead and leaves
+        `_drain_tasks` spinning until its timeout expires.
+        """
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
     def test_scancel_issued_for_worker_and_client(
         self, pipeline_factory: PipelineFactory
     ):
@@ -150,7 +160,7 @@ class TestSlurmShutdown:
 
         with (
             patch("tigerflow.pipeline.submit_to_slurm", return_value=111),
-            patch.object(subprocess, "run") as run,
+            patch.object(subprocess, "run", side_effect=self._no_such_job) as run,
         ):
             pipeline.run()
 

--- a/tests/integration/pipeline/test_task_supervision.py
+++ b/tests/integration/pipeline/test_task_supervision.py
@@ -169,3 +169,35 @@ class TestSlurmShutdown:
         cancel_argv = [call.args[0] for call in run.call_args_list if call.args]
         assert ["scancel", "-n", task.worker_job_name] in cancel_argv
         assert ["scancel", "-n", task.client_job_name] in cancel_argv
+
+    def test_drain_gives_up_on_job_that_stays_queued(
+        self, pipeline_factory: PipelineFactory, monkeypatch: pytest.MonkeyPatch
+    ):
+        """A job still queued after `scancel` must not hold shutdown open forever.
+
+        The drain re-polls squeue on every pass, so a job that keeps reporting
+        PENDING keeps it looping; `scancel` is asynchronous and the job may
+        outlive the request. Only the deadline ends that, which makes this the
+        Slurm analogue of `test_kills_task_that_ignores_terminate`.
+
+        Zeroing the timeout pins the bound itself: squeue never reports the job
+        gone, so a drain that returns can only have hit its deadline.
+        """
+        monkeypatch.setattr("tigerflow.pipeline.settings.pipeline_shutdown_timeout", 0)
+        pipeline = pipeline_factory([SLURM_TASK])
+        pipeline._shutdown_event.set()
+
+        def still_queued(argv, *args, **kwargs) -> subprocess.CompletedProcess:
+            """Report PENDING for every squeue poll, as if scancel were a no-op."""
+            return subprocess.CompletedProcess(argv, 0, stdout=" PENDING", stderr="")
+
+        with (
+            patch("tigerflow.pipeline.submit_to_slurm", return_value=111),
+            patch.object(subprocess, "run", side_effect=still_queued),
+        ):
+            pipeline.run()
+
+        assert pipeline._task_status["gpu"].kind is TaskStatusKind.PENDING, (
+            "The drain must have exited on its deadline with the job still live, "
+            "not because the job was observed gone"
+        )


### PR DESCRIPTION
## Summary

- Terminate tasks based on the live process state instead of the cached status, so tasks that were never polled or whose status went stale are no longer leaked.
- Bound the shutdown drain with a new `pipeline_shutdown_timeout` setting (default 30s), escalating local processes that ignore `SIGTERM` to `SIGKILL`.
- Let a failure to start one task surface its real error instead of being masked by a `KeyError` during shutdown.
- Add integration tests for stale status, `SIGTERM`-ignoring tasks, partial start failure, and a Slurm job that stays queued past `scancel`.
- Document `TIGERFLOW_PIPELINE_SHUTDOWN_TIMEOUT` in the configuration guide.
