### PR TITLE
Periodically warn for long-pending workers

### DIFF
--- a/docs/mkdocs/guides/configuration.md
+++ b/docs/mkdocs/guides/configuration.md
@@ -38,6 +38,7 @@ export TIGERFLOW_ENV_FILE=/path/to/custom.env
 | `TIGERFLOW_SLURM_TASK_SCALE_INTERVAL` | `15` | Interval in seconds between Slurm task scaling checks |
 | `TIGERFLOW_SLURM_TASK_SCALE_WAIT_COUNT` | `8` | Number of consecutive idle checks before removing a worker |
 | `TIGERFLOW_SLURM_TASK_WORKER_STARTUP_TIMEOUT` | `600` | Timeout in seconds for each Slurm task worker to initialize |
+| `TIGERFLOW_SLURM_TASK_WORKER_WARNING_INTERVAL` | `10` | Interval in minutes to log a warning when slurm tasks stay pending |
 
 ## Example: Tuning Slurm Task Behavior
 

--- a/src/tigerflow/pipeline.py
+++ b/src/tigerflow/pipeline.py
@@ -201,6 +201,7 @@ class Pipeline:
                 subprocess.run(["scancel", "-n", task.client_job_name])
             self._drain_tasks()
             logger.info("Pipeline shutdown complete")
+            self._log_pipeline_summary()
             if self._pid_file is not None:
                 self._pid_file.unlink(missing_ok=True)
             if self._received_signal is not None:
@@ -443,6 +444,16 @@ class Pipeline:
             logger.warning("Idle timeout reached, initiating shutdown")
             self._received_signal = signal.SIGTERM
             self._shutdown_event.set()
+    
+    def _log_pipeline_summary(self):
+        n_finished = sum(1 for f in self._finished_dir.iterdir() if f.is_file())
+        logger.info(
+            "Pipeline summary: staged={} / completed={} / failed={}",
+            len(self._filenames),
+            n_finished,
+            len(self._failed_stems()),
+        )
+
 
     @staticmethod
     def _get_subprocess_status(process: subprocess.Popen) -> TaskStatus:

--- a/src/tigerflow/pipeline.py
+++ b/src/tigerflow/pipeline.py
@@ -207,7 +207,6 @@ class Pipeline:
                 subprocess.run(["scancel", "-n", task.client_job_name])
             self._drain_tasks()
             logger.info("Pipeline shutdown complete")
-            self._log_pipeline_summary()
             if self._pid_file is not None:
                 self._pid_file.unlink(missing_ok=True)
             if self._received_signal is not None:
@@ -485,15 +484,6 @@ class Pipeline:
             logger.warning("Idle timeout reached, initiating shutdown")
             self._received_signal = signal.SIGTERM
             self._shutdown_event.set()
-
-    def _log_pipeline_summary(self):
-        n_finished = sum(1 for f in self._finished_dir.iterdir() if f.is_file())
-        logger.info(
-            "Pipeline summary: staged={} / completed={} / failed={}",
-            len(self._filenames),
-            n_finished,
-            len(self._failed_stems()),
-        )
 
     @staticmethod
     def _get_subprocess_status(process: subprocess.Popen) -> TaskStatus:

--- a/src/tigerflow/pipeline.py
+++ b/src/tigerflow/pipeline.py
@@ -336,16 +336,11 @@ class Pipeline:
 
         now = time.time()
         newly_crossed: dict[int, list[int]] = defaultdict(list)
+        warning_interval = settings.slurm_task_worker_warning_interval
         for job_id in pending_ids:
             pending_minutes = (now - since.setdefault(job_id, now)) / 60
-            threshold = (
-                int(pending_minutes // settings.slurm_task_worker_warning_interval)
-                * settings.slurm_task_worker_warning_interval
-            )
-            if (
-                threshold >= settings.slurm_task_worker_warning_interval
-                and threshold > alerted.get(job_id, 0)
-            ):
+            threshold = int(pending_minutes // warning_interval) * warning_interval
+            if threshold >= warning_interval and threshold > alerted.get(job_id, 0):
                 alerted[job_id] = threshold
                 newly_crossed[threshold].append(job_id)
 

--- a/src/tigerflow/pipeline.py
+++ b/src/tigerflow/pipeline.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import threading
 import time
+from collections import defaultdict
 from datetime import datetime, timedelta
 from pathlib import Path
 from types import FrameType
@@ -23,7 +24,7 @@ from tigerflow.models import (
 )
 from tigerflow.settings import settings
 from tigerflow.staging import StagingContext
-from tigerflow.tasks.utils import get_slurm_task_status
+from tigerflow.tasks.utils import get_pending_worker_ids, get_slurm_task_status
 from tigerflow.utils import TEMP_FILE_PREFIX, submit_to_slurm, validate_task_cli
 
 
@@ -148,6 +149,12 @@ class Pipeline:
 
         # Initialize mapping from task name to Slurm job ID
         self._slurm_task_ids: dict[str, int] = dict()
+
+        # Track how long each currently-pending worker job has been pending,
+        # and the last 10-minute threshold logged for it, so warnings repeat
+        # every 10 minutes instead of flooding every poll cycle
+        self._worker_pending_since: dict[str, dict[int, float]] = defaultdict(dict)
+        self._worker_pending_alerted: dict[str, dict[int, int]] = defaultdict(dict)
 
         # Initialize an event to manage graceful shutdown
         self._shutdown_event = threading.Event()
@@ -301,6 +308,7 @@ class Pipeline:
             elif isinstance(task, SlurmTaskConfig):
                 job_id = self._slurm_task_ids[task.name]
                 status = get_slurm_task_status(job_id, task.worker_job_name)
+                self._check_pending_workers(task)
             else:
                 raise ValueError(f"Unsupported task kind: {type(task)}")
 
@@ -316,6 +324,34 @@ class Pipeline:
                     status.kind.name,
                     f" ({status.detail})" if status.detail else "",
                 )
+
+    def _check_pending_workers(self, task: SlurmTaskConfig):
+        """Warn every 10 minutes a worker job spends stuck in the Slurm queue."""
+        pending_ids = get_pending_worker_ids(task.worker_job_name)
+        since = self._worker_pending_since[task.name]
+        alerted = self._worker_pending_alerted[task.name]
+
+        for job_id in list(since):
+            if job_id not in pending_ids:
+                since.pop(job_id, None)
+                alerted.pop(job_id, None)
+
+        now = time.time()
+        newly_crossed: dict[int, list[int]] = defaultdict(list)
+        for job_id in pending_ids:
+            pending_minutes = (now - since.setdefault(job_id, now)) / 60
+            threshold = int(pending_minutes // 10) * 10
+            if threshold >= 10 and threshold > alerted.get(job_id, 0):
+                alerted[job_id] = threshold
+                newly_crossed[threshold].append(job_id)
+
+        for threshold, job_ids in sorted(newly_crossed.items()):
+            logger.info(
+                "[{}] Workers pending more than {} minutes: {}",
+                task.name,
+                threshold,
+                ", ".join(str(job_id) for job_id in sorted(job_ids)),
+            )
 
     def _drain_tasks(self):
         """Wait for terminated tasks to actually exit, both local and Slurm.
@@ -444,7 +480,7 @@ class Pipeline:
             logger.warning("Idle timeout reached, initiating shutdown")
             self._received_signal = signal.SIGTERM
             self._shutdown_event.set()
-    
+
     def _log_pipeline_summary(self):
         n_finished = sum(1 for f in self._finished_dir.iterdir() if f.is_file())
         logger.info(
@@ -453,7 +489,6 @@ class Pipeline:
             n_finished,
             len(self._failed_stems()),
         )
-
 
     @staticmethod
     def _get_subprocess_status(process: subprocess.Popen) -> TaskStatus:

--- a/src/tigerflow/pipeline.py
+++ b/src/tigerflow/pipeline.py
@@ -151,8 +151,7 @@ class Pipeline:
         self._slurm_task_ids: dict[str, int] = dict()
 
         # Track how long each currently-pending worker job has been pending,
-        # and the last 10-minute threshold logged for it, so warnings repeat
-        # every 10 minutes instead of flooding every poll cycle
+        # and the last threshold logged for it
         self._worker_pending_since: dict[str, dict[int, float]] = defaultdict(dict)
         self._worker_pending_alerted: dict[str, dict[int, int]] = defaultdict(dict)
 
@@ -340,13 +339,19 @@ class Pipeline:
         newly_crossed: dict[int, list[int]] = defaultdict(list)
         for job_id in pending_ids:
             pending_minutes = (now - since.setdefault(job_id, now)) / 60
-            threshold = int(pending_minutes // 10) * 10
-            if threshold >= 10 and threshold > alerted.get(job_id, 0):
+            threshold = (
+                int(pending_minutes // settings.slurm_task_worker_warning_interval)
+                * settings.slurm_task_worker_warning_interval
+            )
+            if (
+                threshold >= settings.slurm_task_worker_warning_interval
+                and threshold > alerted.get(job_id, 0)
+            ):
                 alerted[job_id] = threshold
                 newly_crossed[threshold].append(job_id)
 
         for threshold, job_ids in sorted(newly_crossed.items()):
-            logger.info(
+            logger.warning(
                 "[{}] Workers pending more than {} minutes: {}",
                 task.name,
                 threshold,

--- a/src/tigerflow/settings.py
+++ b/src/tigerflow/settings.py
@@ -57,5 +57,11 @@ class TigerflowSettings(BaseSettings):
         description="Timeout in seconds for each Slurm task worker to initialize",
     )
 
+    slurm_task_worker_warning_interval: int = Field(
+        default=10,
+        gt=0,
+        description="Interval in minutes to log a warning when slurm tasks stay pending",
+    )
+
 
 settings = TigerflowSettings()

--- a/src/tigerflow/tasks/utils.py
+++ b/src/tigerflow/tasks/utils.py
@@ -103,6 +103,25 @@ def get_slurm_task_status(client_job_id: int, worker_job_name: str) -> TaskStatu
         )
 
 
+def get_pending_worker_ids(worker_job_name: str) -> list[int]:
+    """Return the Slurm job IDs of workers currently in the PENDING state."""
+    worker_status = subprocess.run(
+        ["squeue", "--me", "-n", worker_job_name, "-h", "-o", "%.18i %.10T"],
+        capture_output=True,
+        text=True,
+    ).stdout
+
+    pending_ids = []
+    for line in worker_status.strip().splitlines():
+        fields = line.split()
+        if len(fields) != 2:
+            continue
+        job_id, state = fields
+        if state == "PENDING":
+            pending_ids.append(int(job_id))
+    return pending_ids
+
+
 def write_error_file(error_path: Path, input_file: str) -> None:
     """Write structured error JSON for a failed file.
 

--- a/src/tigerflow/tasks/utils.py
+++ b/src/tigerflow/tasks/utils.py
@@ -105,21 +105,13 @@ def get_slurm_task_status(client_job_id: int, worker_job_name: str) -> TaskStatu
 
 def get_pending_worker_ids(worker_job_name: str) -> list[int]:
     """Return the Slurm job IDs of workers currently in the PENDING state."""
-    worker_status = subprocess.run(
-        ["squeue", "--me", "-n", worker_job_name, "-h", "-o", "%.18i %.10T"],
+    pending_ids = subprocess.run(
+        ["squeue", "--me", "-n", worker_job_name, "-h", "-t", "PENDING", "-o", "%i"],
         capture_output=True,
         text=True,
     ).stdout
 
-    pending_ids = []
-    for line in worker_status.strip().splitlines():
-        fields = line.split()
-        if len(fields) != 2:
-            continue
-        job_id, state = fields
-        if state == "PENDING":
-            pending_ids.append(int(job_id))
-    return pending_ids
+    return [int(job_id) for job_id in pending_ids.split()]
 
 
 def write_error_file(error_path: Path, input_file: str) -> None:

--- a/src/tigerflow/tasks/utils.py
+++ b/src/tigerflow/tasks/utils.py
@@ -111,7 +111,7 @@ def get_pending_worker_ids(worker_job_name: str) -> list[int]:
         text=True,
     ).stdout
 
-    return [int(job_id) for job_id in pending_ids.split()]
+    return [int(job_id) for job_id in pending_ids.split() if job_id.isdigit()]
 
 
 def write_error_file(error_path: Path, input_file: str) -> None:

--- a/tests/integration/pipeline/conftest.py
+++ b/tests/integration/pipeline/conftest.py
@@ -137,6 +137,27 @@ def error_logs() -> Iterator[list[str]]:
         logger.remove(sink_id)
 
 
+@pytest.fixture
+def pending_worker_logs() -> Iterator[list[str]]:
+    """Yield a list collecting the message of every "Workers pending" record logged.
+
+    Filtered by message content rather than level: `_check_task_status` also logs
+    an INFO status-change record on the same call, which a level-only sink would
+    mix in and throw off exact-count assertions.
+    """
+    records: list[str] = []
+
+    sink_id = logger.add(
+        lambda message: records.append(message.record["message"]),
+        level="INFO",
+        filter=lambda record: "Workers pending" in record["message"],
+    )
+    try:
+        yield records
+    finally:
+        logger.remove(sink_id)
+
+
 @pytest.fixture(autouse=True)
 def reset_logger_sinks():
     """Drop file sinks added by `Pipeline.run()` after each test.

--- a/tests/integration/pipeline/conftest.py
+++ b/tests/integration/pipeline/conftest.py
@@ -141,7 +141,7 @@ def error_logs() -> Iterator[list[str]]:
 def pending_worker_logs() -> Iterator[list[str]]:
     """Yield a list collecting the message of every "Workers pending" record logged.
 
-    Filtered by message content rather than level: `_check_task_status` also logs
+    Filtered by message content as well as level: `_check_task_status` also logs
     an INFO status-change record on the same call, which a level-only sink would
     mix in and throw off exact-count assertions.
     """
@@ -149,7 +149,7 @@ def pending_worker_logs() -> Iterator[list[str]]:
 
     sink_id = logger.add(
         lambda message: records.append(message.record["message"]),
-        level="INFO",
+        level="WARNING",
         filter=lambda record: "Workers pending" in record["message"],
     )
     try:

--- a/tests/integration/pipeline/test_task_supervision.py
+++ b/tests/integration/pipeline/test_task_supervision.py
@@ -137,7 +137,11 @@ class TestSlurmTimeout:
 
 
 class TestPendingWorkerAlerts:
-    """Workers stuck PENDING in the Slurm queue are warned about every 10 minutes."""
+    """Workers stuck PENDING in the Slurm queue are warned about periodically.
+
+    The default interval is 10 minutes, configurable via
+    `TIGERFLOW_SLURM_TASK_WORKER_WARNING_INTERVAL`.
+    """
 
     def test_logs_when_worker_crosses_every_ten_minutes(
         self,
@@ -148,8 +152,8 @@ class TestPendingWorkerAlerts:
         pipeline = pipeline_factory([SLURM_TASK])
         pipeline._slurm_task_ids["gpu"] = 111
 
-        clock = [1000.0]
-        monkeypatch.setattr("tigerflow.pipeline.time.time", lambda: clock[0])
+        clock = 1000.0
+        monkeypatch.setattr("tigerflow.pipeline.time.time", lambda: clock)
 
         with (
             patch(
@@ -164,11 +168,11 @@ class TestPendingWorkerAlerts:
             pipeline._check_task_status()
             assert pending_worker_logs == [], "First observation only starts the clock"
 
-            clock[0] += 601
+            clock += 601
             pipeline._check_task_status()
-            clock[0] += 600
+            clock += 600
             pipeline._check_task_status()
-            clock[0] += 60  # Same threshold must not be logged twice
+            clock += 60  # Same threshold must not be logged twice
             pipeline._check_task_status()
 
         assert len(pending_worker_logs) == 2
@@ -187,8 +191,8 @@ class TestPendingWorkerAlerts:
         pipeline = pipeline_factory([SLURM_TASK])
         pipeline._slurm_task_ids["gpu"] = 111
 
-        clock = [1000.0]
-        monkeypatch.setattr("tigerflow.pipeline.time.time", lambda: clock[0])
+        clock = 1000.0
+        monkeypatch.setattr("tigerflow.pipeline.time.time", lambda: clock)
 
         with patch(
             "tigerflow.pipeline.get_slurm_task_status",
@@ -200,14 +204,14 @@ class TestPendingWorkerAlerts:
             ):
                 pipeline._check_task_status()
 
-            clock[0] += 601
+            clock += 601
             with patch(
                 "tigerflow.pipeline.get_pending_worker_ids",
                 return_value=[],  # Job started running before the 10-minute mark
             ):
                 pipeline._check_task_status()
 
-            clock[0] += 601
+            clock += 601
             with patch(
                 "tigerflow.pipeline.get_pending_worker_ids",
                 return_value=[847645],  # Re-queued later, clock restarts
@@ -215,6 +219,38 @@ class TestPendingWorkerAlerts:
                 pipeline._check_task_status()
 
         assert pending_worker_logs == []
+
+    def test_warning_interval_is_configurable(
+        self,
+        pipeline_factory: PipelineFactory,
+        monkeypatch: pytest.MonkeyPatch,
+        pending_worker_logs: list[str],
+    ):
+        pipeline = pipeline_factory([SLURM_TASK])
+        pipeline._slurm_task_ids["gpu"] = 111
+        monkeypatch.setattr(
+            "tigerflow.pipeline.settings.slurm_task_worker_warning_interval", 5
+        )
+
+        clock = 1000.0
+        monkeypatch.setattr("tigerflow.pipeline.time.time", lambda: clock)
+
+        with (
+            patch(
+                "tigerflow.pipeline.get_slurm_task_status",
+                return_value=slurm_status(TaskStatusKind.ACTIVE),
+            ),
+            patch(
+                "tigerflow.pipeline.get_pending_worker_ids",
+                return_value=[847645],
+            ),
+        ):
+            pipeline._check_task_status()
+            clock += 301
+            pipeline._check_task_status()
+
+        assert len(pending_worker_logs) == 1
+        assert "5 minutes" in pending_worker_logs[0]
 
 
 class TestSlurmShutdown:

--- a/tests/integration/pipeline/test_task_supervision.py
+++ b/tests/integration/pipeline/test_task_supervision.py
@@ -127,12 +127,94 @@ class TestSlurmTimeout:
                     slurm_status(TaskStatusKind.PENDING, "Reason: Priority"),
                 ],
             ) as poll,
+            patch("tigerflow.pipeline.get_pending_worker_ids", return_value=[]),
         ):
             pipeline._run_tracking_cycle()
             pipeline._run_tracking_cycle()
 
         assert resubmit.call_count == 1, "Only the timed-out job should be resubmitted"
         assert poll.call_args_list[1].args[0] == 222, "Second poll must use the new ID"
+
+
+class TestPendingWorkerAlerts:
+    """Workers stuck PENDING in the Slurm queue are warned about every 10 minutes."""
+
+    def test_logs_when_worker_crosses_every_ten_minutes(
+        self,
+        pipeline_factory: PipelineFactory,
+        monkeypatch: pytest.MonkeyPatch,
+        pending_worker_logs: list[str],
+    ):
+        pipeline = pipeline_factory([SLURM_TASK])
+        pipeline._slurm_task_ids["gpu"] = 111
+
+        clock = [1000.0]
+        monkeypatch.setattr("tigerflow.pipeline.time.time", lambda: clock[0])
+
+        with (
+            patch(
+                "tigerflow.pipeline.get_slurm_task_status",
+                return_value=slurm_status(TaskStatusKind.ACTIVE),
+            ),
+            patch(
+                "tigerflow.pipeline.get_pending_worker_ids",
+                return_value=[847645, 847649],
+            ),
+        ):
+            pipeline._check_task_status()
+            assert pending_worker_logs == [], "First observation only starts the clock"
+
+            clock[0] += 601
+            pipeline._check_task_status()
+            clock[0] += 600
+            pipeline._check_task_status()
+            clock[0] += 60  # Same threshold must not be logged twice
+            pipeline._check_task_status()
+
+        assert len(pending_worker_logs) == 2
+        assert "[gpu]" in pending_worker_logs[0]
+        assert "10 minutes" in pending_worker_logs[0]
+        assert "20 minutes" in pending_worker_logs[1]
+        assert "847645" in pending_worker_logs[0]
+        assert "847649" in pending_worker_logs[0]
+
+    def test_stops_tracking_once_worker_leaves_the_queue(
+        self,
+        pipeline_factory: PipelineFactory,
+        monkeypatch: pytest.MonkeyPatch,
+        pending_worker_logs: list[str],
+    ):
+        pipeline = pipeline_factory([SLURM_TASK])
+        pipeline._slurm_task_ids["gpu"] = 111
+
+        clock = [1000.0]
+        monkeypatch.setattr("tigerflow.pipeline.time.time", lambda: clock[0])
+
+        with patch(
+            "tigerflow.pipeline.get_slurm_task_status",
+            return_value=slurm_status(TaskStatusKind.ACTIVE),
+        ):
+            with patch(
+                "tigerflow.pipeline.get_pending_worker_ids",
+                return_value=[847645],
+            ):
+                pipeline._check_task_status()
+
+            clock[0] += 601
+            with patch(
+                "tigerflow.pipeline.get_pending_worker_ids",
+                return_value=[],  # Job started running before the 10-minute mark
+            ):
+                pipeline._check_task_status()
+
+            clock[0] += 601
+            with patch(
+                "tigerflow.pipeline.get_pending_worker_ids",
+                return_value=[847645],  # Re-queued later, clock restarts
+            ):
+                pipeline._check_task_status()
+
+        assert pending_worker_logs == []
 
 
 class TestSlurmShutdown:


### PR DESCRIPTION
Updates the pipeline log to:

1. ~Log the number of files staged, completed, and failed upon pipeline termination~
2. Log when worker(s) have been pending for more than 10, 20, 30, ... minutes. ~In #17, this was intended to be a warning, but I just made it `info` level since nothing is technically wrong. This can be easily updated.~

Ref #17 