### PR TITLE
inject input_ext and output_ext into context

### DIFF
--- a/src/tigerflow/tasks/local.py
+++ b/src/tigerflow/tasks/local.py
@@ -62,6 +62,10 @@ class LocalTask(Task):
         for key, value in self.config.params.items():
             setattr(self._context, key, value)
 
+        # Inject input_ext and output_ext into context
+        setattr(self._context, "input_ext", self.config.input_ext)
+        setattr(self._context, "output_ext", self.config.output_ext)
+
         # Run common setup
         logger.info("Setting up task")
         self.setup(self._context)

--- a/src/tigerflow/tasks/local.py
+++ b/src/tigerflow/tasks/local.py
@@ -62,7 +62,7 @@ class LocalTask(Task):
         for key, value in self.config.params.items():
             setattr(self._context, key, value)
 
-        # Inject non-custom task params into contex
+        # Inject non-custom task params into context
         setattr(self._context, "input_ext", self.config.input_ext)
         setattr(self._context, "output_ext", self.config.output_ext)
 

--- a/src/tigerflow/tasks/local.py
+++ b/src/tigerflow/tasks/local.py
@@ -62,7 +62,7 @@ class LocalTask(Task):
         for key, value in self.config.params.items():
             setattr(self._context, key, value)
 
-        # Inject input_ext and output_ext into context
+        # Inject non-custom task params into contex
         setattr(self._context, "input_ext", self.config.input_ext)
         setattr(self._context, "output_ext", self.config.output_ext)
 

--- a/src/tigerflow/tasks/local_async.py
+++ b/src/tigerflow/tasks/local_async.py
@@ -93,7 +93,8 @@ class LocalAsyncTask(Task):
             # Inject custom params into context
             for key, value in self.config.params.items():
                 setattr(self._context, key, value)
-            # Inject input_ext and output_ext into context
+
+            # Inject non-custom task params into context
             setattr(self._context, "input_ext", self.config.input_ext)
             setattr(self._context, "output_ext", self.config.output_ext)
 

--- a/src/tigerflow/tasks/local_async.py
+++ b/src/tigerflow/tasks/local_async.py
@@ -93,6 +93,9 @@ class LocalAsyncTask(Task):
             # Inject custom params into context
             for key, value in self.config.params.items():
                 setattr(self._context, key, value)
+            # Inject input_ext and output_ext into context
+            setattr(self._context, "input_ext", self.config.input_ext)
+            setattr(self._context, "output_ext", self.config.output_ext)
 
             # Run common setup
             logger.info("Setting up task")

--- a/src/tigerflow/tasks/slurm.py
+++ b/src/tigerflow/tasks/slurm.py
@@ -60,6 +60,7 @@ class SlurmTask(Task):
         # Avoid capturing unpicklable `self` in closures sent to workers
         setup_failed_sentinel = self.config.log_dir / ".setup-failed"
         params = self.config.params
+        input_ext = self.config.input_ext
         output_ext = self.config.output_ext
         setup_func = type(self).setup
         run_func = type(self).run
@@ -72,8 +73,8 @@ class SlurmTask(Task):
                     context = SetupContext()
                     for key, value in params.items():
                         setattr(context, key, value)
-                    setattr(self._context, "input_ext", self.config.input_ext)
-                    setattr(self._context, "output_ext", self.config.output_ext)
+                    setattr(context, "input_ext", input_ext)
+                    setattr(context, "output_ext", output_ext)
                     loop = asyncio.get_running_loop()
                     await loop.run_in_executor(None, setup_func, context)
                     context.freeze()  # Make it read-only

--- a/src/tigerflow/tasks/slurm.py
+++ b/src/tigerflow/tasks/slurm.py
@@ -72,6 +72,8 @@ class SlurmTask(Task):
                     context = SetupContext()
                     for key, value in params.items():
                         setattr(context, key, value)
+                    setattr(self._context, "input_ext", self.config.input_ext)
+                    setattr(self._context, "output_ext", self.config.output_ext)
                     loop = asyncio.get_running_loop()
                     await loop.run_in_executor(None, setup_func, context)
                     context.freeze()  # Make it read-only


### PR DESCRIPTION
For all three task types, injects `input_ext` and `output_ext` into the task's context.  (Manually tested with a local task, run as a pipeline.)

I tried to update tests to assert that these two parameters are present in a task's config, but I didn't see any existing tests that would allow me to easily add this. A larger testing refactor could be explored to make this possible. 

Closes #99 