### PR TITLE
Fix completion when terminal tasks finish on different cycles

### DIFF
--- a/src/tigerflow/pipeline.py
+++ b/src/tigerflow/pipeline.py
@@ -433,10 +433,12 @@ class Pipeline:
         }
 
     def _handle_processed_files(self):
-        # Identify *newly* processed files for each task
-        processed_filenames_by_task: dict[str, set[str]] = {
-            task.name: set() for task in self._config.tasks
-        }
+        terminal_tasks = self._config.terminal_tasks
+        terminal_task_names = {task.name for task in terminal_tasks}
+
+        # Identify *newly* processed files. Outputs from a terminal task
+        # become completion candidates.
+        candidate_file_ids: set[str] = set()
         for task in self._config.tasks:
             for file in task.output_dir.iterdir():
                 if (
@@ -446,21 +448,24 @@ class Pipeline:
                     and file.name not in self._task_processed_filenames[task.name]
                 ):
                     self._task_processed_filenames[task.name].add(file.name)
-                    processed_filenames_by_task[task.name].add(file.name)
+                    if task.name in terminal_task_names:
+                        candidate_file_ids.add(file.name.removesuffix(task.output_ext))
                     if task.keep_output:
                         new_file = self._output_dir / task.name / file.name
                         shutil.copy(file, new_file)
 
-        # Identify files that have completed all pipeline tasks
-        completed_file_ids: set[str] = set.intersection(
-            *(
-                {
-                    filename.removesuffix(task.output_ext)
-                    for filename in processed_filenames_by_task[task.name]
-                }
-                for task in self._config.terminal_tasks
+        # Identify files that have completed all pipeline tasks. Terminal tasks
+        # rarely finish a file within the same polling cycle, so candidates are
+        # confirmed against `_task_processed_filenames`, which is never pruned.
+        completed_file_ids: set[str] = {
+            file_id
+            for file_id in candidate_file_ids
+            if all(
+                f"{file_id}{task.output_ext}"
+                in self._task_processed_filenames[task.name]
+                for task in terminal_tasks
             )
-        )
+        }
 
         # Record completion and clean up staged/input files
         for file_id in completed_file_ids:

--- a/tests/integration/pipeline/test_multi_task.py
+++ b/tests/integration/pipeline/test_multi_task.py
@@ -6,8 +6,6 @@ only once every terminal task has finished with it.
 
 from pathlib import Path
 
-import pytest
-
 from .helpers import PipelineFactory, stage_file, task_spec, write_output
 
 CHAIN = [
@@ -185,12 +183,6 @@ class TestFanOutCompletion:
         assert (pipeline._finished_dir / "a.txt").exists()
         assert not (pipeline._symlinks_dir / "a.txt").exists()
 
-    @pytest.mark.xfail(
-        reason="Completion intersects only files seen in the current cycle, so a "
-        "terminal task recorded in an earlier cycle drops out and the file is "
-        "never completed",
-        strict=True,
-    )
     def test_finishes_when_terminal_tasks_finish_on_different_cycles(
         self, pipeline_factory: PipelineFactory, input_dir: Path
     ):
@@ -213,11 +205,6 @@ class TestFanOutCompletion:
             "File should be completed once every terminal task has finished"
         )
 
-    @pytest.mark.xfail(
-        reason="Same root cause as staggered completion: the file is never "
-        "completed, so its staged symlink and task outputs are never cleaned up",
-        strict=True,
-    )
     def test_staggered_completion_does_not_leak(
         self, pipeline_factory: PipelineFactory, input_dir: Path
     ):
@@ -236,3 +223,47 @@ class TestFanOutCompletion:
         for name in ("leafA", "leafB"):
             task = next(t for t in pipeline._config.tasks if t.name == name)
             assert not (task.output_dir / "a.txt").exists()
+
+    def test_completion_stays_recorded_after_output_cleanup(
+        self, pipeline_factory: PipelineFactory, input_dir: Path
+    ):
+        """A completed file is not reprocessed when its task output reappears.
+
+        Completion cleanup deletes task outputs, but `_task_processed_filenames`
+        keeps the record on purpose: pruning it would let a reappearing output
+        re-complete the file and copy it out a second time.
+        """
+        pipeline = pipeline_factory(
+            [
+                task_spec("root"),
+                task_spec("leafA", depends_on="root", keep_output=True),
+                task_spec("leafB", depends_on="root", keep_output=True),
+            ]
+        )
+
+        stage_file(pipeline, input_dir, "a")
+
+        write_output(pipeline, "a", task="leafA")
+        pipeline._handle_processed_files()
+        write_output(pipeline, "a", task="leafB")
+        pipeline._handle_processed_files()
+
+        assert (pipeline._finished_dir / "a.txt").exists()
+
+        kept_copy = pipeline._output_dir / "leafA" / "a.txt"
+        assert kept_copy.exists(), "keep_output should have copied the output out"
+
+        # Remove the copy so a repeated copy is detectable rather than silently
+        # overwriting the same path
+        kept_copy.unlink()
+
+        write_output(pipeline, "a", task="leafA")
+        pipeline._handle_processed_files()
+
+        assert not kept_copy.exists(), (
+            "A completed file must not be copied out a second time"
+        )
+        for name in ("leafA", "leafB"):
+            assert "a.txt" in pipeline._task_processed_filenames[name], (
+                "Completion must stay recorded after the output is cleaned up"
+            )


### PR DESCRIPTION
## Summary

A file was only marked complete if every terminal task produced its output within the same polling cycle. With fan-out, outputs usually land on different cycles, so the file was never completed and its staged symlink and task outputs were left behind.

- `_handle_processed_files` now checks new terminal-task outputs against the running record of what each terminal task has processed.
- Added a test that a completed file is not copied out again if a terminal task's output reappears after cleanup — this is why the processed-file record is never pruned.
