### PR TITLE
surface warnings in the report dashboard

### DIFF
--- a/src/tigerflow/cli/report.py
+++ b/src/tigerflow/cli/report.py
@@ -74,6 +74,37 @@ def _compute_metrics_summary(metrics: dict[str, list[FileMetrics]]) -> dict:
     }
 
 
+def _compute_warning_summary(metrics: dict[str, list[FileMetrics]]) -> dict:
+    """Compute warning totals from metrcis"""
+    warnings = {}
+    for task, task_metrics in metrics.items():
+        if task not in warnings.keys():
+            warnings[task] = {
+                "total_num_warnings": 0,
+                "min_num_warnings": 0,
+                "max_num_warnings": 0,
+                "total_file_num": 0,
+            }
+        for m in task_metrics:
+            warnings[task]["total_num_warnings"] = (
+                warnings[task]["total_num_warnings"] + m.num_warnings
+            )
+            warnings[task]["min_num_warnings"] = min(
+                warnings[task]["min_num_warnings"], m.num_warnings
+            )
+            warnings[task]["max_num_warnings"] = max(
+                warnings[task]["max_num_warnings"], m.num_warnings
+            )
+            warnings[task]["total_file_num"] = warnings[task]["total_file_num"] + 1
+
+    for task in warnings.keys():
+        warnings[task]["avg_num_warnings"] = (
+            warnings[task]["total_num_warnings"] / warnings[task]["total_file_num"]
+        )
+
+    return warnings
+
+
 def _build_dashboard_panel(report: PipelineReport) -> Panel:
     """Build the dashboard panel."""
 
@@ -181,6 +212,22 @@ def _build_dashboard_panel(report: PipelineReport) -> Panel:
         if total_errors > 5:
             lines.append(f"  [dim]... +{total_errors - 5} more[/dim]")
         lines.append("")
+
+    # Warnings summary (for this run)
+    total_warnings = sum(
+        m.num_warnings
+        for metrics in report.metrics.values()
+        for m in metrics
+        if m.status == "success"  # only counts warnings for successful files (?)
+    )
+    if total_warnings > 0:
+        lines.append(f"[bold]Warnings:[/bold] {total_warnings}")
+        warning_summary = _compute_warning_summary(report.metrics)
+        for task_name, warning_data in warning_summary.items():
+            if warning_data["total_num_warnings"] > 0:
+                lines.append(
+                    f"  [dim]{task_name}[/dim]  [yellow]{warning_data['total_num_warnings']} warnings ({warning_data['min_num_warnings']}-{warning_data['max_num_warnings']}, avg={warning_data['avg_num_warnings']})[/yellow]"
+                )
 
     content = "\n".join(lines)
     return Panel(content, title="[bold]tigerflow report[/bold]", title_align="left")

--- a/src/tigerflow/cli/report.py
+++ b/src/tigerflow/cli/report.py
@@ -89,18 +89,18 @@ def _compute_warning_summary(metrics: dict[str, list[FileMetrics]]) -> dict:
             warnings[task]["total_num_warnings"] = (
                 warnings[task]["total_num_warnings"] + m.num_warnings
             )
-            warnings[task]["min_num_warnings"] = min(
-                warnings[task]["min_num_warnings"], m.num_warnings
-            )
-            warnings[task]["max_num_warnings"] = max(
-                warnings[task]["max_num_warnings"], m.num_warnings
-            )
+            # warnings[task]["min_num_warnings"] = min(
+            #     warnings[task]["min_num_warnings"], m.num_warnings
+            # )
+            # warnings[task]["max_num_warnings"] = max(
+            #     warnings[task]["max_num_warnings"], m.num_warnings
+            # )
             warnings[task]["total_file_num"] = warnings[task]["total_file_num"] + 1
 
-    for task in warnings.keys():
-        warnings[task]["avg_num_warnings"] = (
-            warnings[task]["total_num_warnings"] / warnings[task]["total_file_num"]
-        )
+    # for task in warnings.keys():
+    #     warnings[task]["avg_num_warnings"] = (
+    #         warnings[task]["total_num_warnings"] / warnings[task]["total_file_num"]
+    #     )
 
     return warnings
 
@@ -215,10 +215,7 @@ def _build_dashboard_panel(report: PipelineReport) -> Panel:
 
     # Warnings summary (for this run)
     total_warnings = sum(
-        m.num_warnings
-        for metrics in report.metrics.values()
-        for m in metrics
-        if m.status == "success"  # only counts warnings for successful files (?)
+        m.num_warnings for metrics in report.metrics.values() for m in metrics
     )
     if total_warnings > 0:
         lines.append(f"[bold]Warnings:[/bold] {total_warnings}")
@@ -226,7 +223,7 @@ def _build_dashboard_panel(report: PipelineReport) -> Panel:
         for task_name, warning_data in warning_summary.items():
             if warning_data["total_num_warnings"] > 0:
                 lines.append(
-                    f"  [dim]{task_name}[/dim]  [yellow]{warning_data['total_num_warnings']} warnings ({warning_data['min_num_warnings']}-{warning_data['max_num_warnings']}, avg={warning_data['avg_num_warnings']})[/yellow]"
+                    f"  [dim]{task_name}[/dim]  [yellow]{warning_data['total_num_warnings']} warnings across {warning_data['total_file_num']} file(s)[/yellow]   See logs in .tigerflow/{task_name} for more details"
                 )
 
     content = "\n".join(lines)

--- a/src/tigerflow/cli/report.py
+++ b/src/tigerflow/cli/report.py
@@ -74,37 +74,6 @@ def _compute_metrics_summary(metrics: dict[str, list[FileMetrics]]) -> dict:
     }
 
 
-def _compute_warning_summary(metrics: dict[str, list[FileMetrics]]) -> dict:
-    """Compute warning totals from metrcis"""
-    warnings = {}
-    for task, task_metrics in metrics.items():
-        if task not in warnings.keys():
-            warnings[task] = {
-                "total_num_warnings": 0,
-                "min_num_warnings": 0,
-                "max_num_warnings": 0,
-                "total_file_num": 0,
-            }
-        for m in task_metrics:
-            warnings[task]["total_num_warnings"] = (
-                warnings[task]["total_num_warnings"] + m.num_warnings
-            )
-            # warnings[task]["min_num_warnings"] = min(
-            #     warnings[task]["min_num_warnings"], m.num_warnings
-            # )
-            # warnings[task]["max_num_warnings"] = max(
-            #     warnings[task]["max_num_warnings"], m.num_warnings
-            # )
-            warnings[task]["total_file_num"] = warnings[task]["total_file_num"] + 1
-
-    # for task in warnings.keys():
-    #     warnings[task]["avg_num_warnings"] = (
-    #         warnings[task]["total_num_warnings"] / warnings[task]["total_file_num"]
-    #     )
-
-    return warnings
-
-
 def _build_dashboard_panel(report: PipelineReport) -> Panel:
     """Build the dashboard panel."""
 
@@ -215,15 +184,14 @@ def _build_dashboard_panel(report: PipelineReport) -> Panel:
 
     # Warnings summary (for this run)
     total_warnings = sum(
-        m.num_warnings for metrics in report.metrics.values() for m in metrics
+        task_warnings["num_warnings"] for task_warnings in report.num_warnings.values()
     )
     if total_warnings > 0:
         lines.append(f"[bold]Warnings:[/bold] {total_warnings}")
-        warning_summary = _compute_warning_summary(report.metrics)
-        for task_name, warning_data in warning_summary.items():
-            if warning_data["total_num_warnings"] > 0:
+        for task_name, warning_data in report.num_warnings.items():
+            if warning_data["num_warnings"] > 0:
                 lines.append(
-                    f"  [dim]{task_name}[/dim]  [yellow]{warning_data['total_num_warnings']} warnings across {warning_data['total_file_num']} file(s)[/yellow]   See logs in .tigerflow/{task_name} for more details"
+                    f"  [dim]{task_name}[/dim]  [yellow]{warning_data['num_warnings']} warnings across {warning_data['num_files_processed']} file(s)[/yellow]   See logs in .tigerflow/{task_name} for more details"
                 )
 
     content = "\n".join(lines)

--- a/src/tigerflow/models.py
+++ b/src/tigerflow/models.py
@@ -38,12 +38,11 @@ class TaskStatus(BaseModel):
 class FileMetrics(BaseModel):
     """Timing metrics for a single file processed by a task."""
 
-    file: str = ""
+    file: str
     task: str
-    started_at: datetime = datetime.now()
-    finished_at: datetime = datetime.now()
-    status: Literal["success", "error", "pending"] = "pending"
-    num_warnings: int = 0
+    started_at: datetime
+    finished_at: datetime
+    status: Literal["success", "error"]
 
     @property
     def duration_ms(self) -> float:
@@ -492,6 +491,7 @@ class PipelineReport(BaseModel):
     staged: int | None = None  # None if stopped
     tasks: list[TaskProgress] = []
     metrics: dict[str, list[FileMetrics]] = {}
+    num_warnings: dict[str, dict[str, int]] = {}
     errors: dict[str, list[FileError]] = {}
 
 
@@ -571,34 +571,70 @@ class PipelineOutput:
             for log_file in log_files:
                 try:
                     with open(log_file) as f:
-                        current_file = ""
                         for line in f:
-                            if "| INFO     | Starting processing: " in line:
-                                current_file = FileMetrics(task=task_dir.name)  # Update
-                            if not current_file:
+                            if "METRICS" not in line:
                                 continue
-                            if "| WARNING  |" in line:
-                                current_file.num_warnings += 1
+                            start = line.find("{")
+                            if start == -1:
                                 continue
-                            if "| METRICS  |" in line:
-                                start = line.find("{")
-                                if start == -1:
-                                    continue
-                                data = json.loads(line[start:])
-                                current_file.file = data["file"]
-                                current_file.started_at = datetime.fromisoformat(
-                                    data["started_at"]
+                            data = json.loads(line[start:])
+                            metrics.append(
+                                FileMetrics(
+                                    file=data["file"],
+                                    task=task_dir.name,
+                                    started_at=datetime.fromisoformat(
+                                        data["started_at"]
+                                    ),
+                                    finished_at=datetime.fromisoformat(
+                                        data["finished_at"]
+                                    ),
+                                    status=data["status"],
                                 )
-                                current_file.finished_at = datetime.fromisoformat(
-                                    data["finished_at"]
-                                )
-                                current_file.status = data["status"]
-                                metrics.append(current_file)
-                                current_file = ""
+                            )
                 except (OSError, json.JSONDecodeError, KeyError):
                     continue
 
         return metrics
+
+    def _parse_warnings(self) -> dict[str, dict[str, int]]:
+        """Parse WARNINGS from task log files.
+
+        Reads from:
+        - {task}/logs/{pid}/task-{pid}.log (local/local_async tasks)
+        - {task}/logs/{pid}/task-worker-{job_id}.log (Slurm worker logs)
+        """
+        all_warnings = {}
+
+        for task_dir in self._get_task_dirs():
+            log_files = list(task_dir.glob("logs/**/task*.log"))
+
+            for log_file in log_files:
+                if task_dir.name not in all_warnings:
+                    all_warnings[task_dir.name] = {
+                        "num_files_processed": 0,
+                        "num_warnings": 0,
+                    }
+                try:
+                    with open(log_file) as f:
+                        for line in f:
+                            if "METRICS" in line:
+                                all_warnings[task_dir.name]["num_files_processed"] = (
+                                    all_warnings[task_dir.name]["num_files_processed"]
+                                    + 1
+                                )
+                            if "WARNING" in line:
+                                if re.search(
+                                    r"Received signal \d+, initiating shutdown",
+                                    line,
+                                ):
+                                    continue
+                                all_warnings[task_dir.name]["num_warnings"] = (
+                                    all_warnings[task_dir.name]["num_warnings"] + 1
+                                )
+
+                except OSError:
+                    continue
+        return all_warnings
 
     def report(self) -> PipelineReport:
         """Generate a complete pipeline status report."""
@@ -672,6 +708,7 @@ class PipelineOutput:
         # === Per-Task Progress (from METRICS logs, all runs) ===
 
         all_metrics = self._parse_all_metrics()
+        warnings = self._parse_warnings()
         task_meta = self._get_task_meta()
 
         # Group metrics by task
@@ -726,5 +763,6 @@ class PipelineOutput:
             staged=len(staged_stems) if is_running else None,
             tasks=tasks,
             metrics=metrics_by_task,
+            num_warnings=warnings,
             errors=errors,
         )

--- a/src/tigerflow/models.py
+++ b/src/tigerflow/models.py
@@ -38,11 +38,12 @@ class TaskStatus(BaseModel):
 class FileMetrics(BaseModel):
     """Timing metrics for a single file processed by a task."""
 
-    file: str
+    file: str = ""
     task: str
-    started_at: datetime
-    finished_at: datetime
-    status: Literal["success", "error"]
+    started_at: datetime = datetime.now()
+    finished_at: datetime = datetime.now()
+    status: Literal["success", "error", "pending"] = "pending"
+    num_warnings: int = 0
 
     @property
     def duration_ms(self) -> float:
@@ -570,26 +571,30 @@ class PipelineOutput:
             for log_file in log_files:
                 try:
                     with open(log_file) as f:
+                        current_file = ""
                         for line in f:
-                            if "METRICS" not in line:
+                            if "| INFO     | Starting processing: " in line:
+                                current_file = FileMetrics(task=task_dir.name)  # Update
+                            if not current_file:
                                 continue
-                            start = line.find("{")
-                            if start == -1:
+                            if "| WARNING  |" in line:
+                                current_file.num_warnings += 1
                                 continue
-                            data = json.loads(line[start:])
-                            metrics.append(
-                                FileMetrics(
-                                    file=data["file"],
-                                    task=task_dir.name,
-                                    started_at=datetime.fromisoformat(
-                                        data["started_at"]
-                                    ),
-                                    finished_at=datetime.fromisoformat(
-                                        data["finished_at"]
-                                    ),
-                                    status=data["status"],
+                            if "| METRICS  |" in line:
+                                start = line.find("{")
+                                if start == -1:
+                                    continue
+                                data = json.loads(line[start:])
+                                current_file.file = data["file"]
+                                current_file.started_at = datetime.fromisoformat(
+                                    data["started_at"]
                                 )
-                            )
+                                current_file.finished_at = datetime.fromisoformat(
+                                    data["finished_at"]
+                                )
+                                current_file.status = data["status"]
+                                metrics.append(current_file)
+                                current_file = ""
                 except (OSError, json.JSONDecodeError, KeyError):
                     continue
 

--- a/tests/unit/cli/test_report.py
+++ b/tests/unit/cli/test_report.py
@@ -248,7 +248,10 @@ class TestAllRunsMetrics:
         all_lines = []
         for i in range(5):
             all_lines.append(
-                f"2026-03-10 10:00:01 | METRICS | {json.dumps({'file': f'file{i}.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'success'})}"
+                f"2026-03-10 10:00:01 | INFO     | Starting processing:  file{i}.txt"
+            )
+            all_lines.append(
+                f"2026-03-10 10:00:01 | METRICS  | {json.dumps({'file': f'file{i}.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'success'})}"
             )
         (log_dir / "task-12345.log").write_text("\n".join(all_lines))
 
@@ -302,7 +305,10 @@ class TestTaskProgress:
         for i in range(8):
             status = "success" if i < 6 else "error"
             task_lines.append(
-                f"2026-03-10 12:00:01 | METRICS | {json.dumps({'file': f'file{i}.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': status})}"
+                f"2026-03-10 12:00:01 | INFO     | Starting processing:  file{i}.txt"
+            )
+            task_lines.append(
+                f"2026-03-10 12:00:01 | METRICS  | {json.dumps({'file': f'file{i}.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': status})}"
             )
         (log_dir / "task-100.log").write_text("\n".join(task_lines))
 
@@ -351,7 +357,10 @@ class TestTaskProgress:
         for i in range(10):
             status = "success" if i < 8 else "error"
             lines1.append(
-                f"2026-03-10 12:00:01 | METRICS | {json.dumps({'file': f'file{i}.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': status})}"
+                f"2026-03-10 12:00:01 | INFO     | Starting processing:  file{i}.txt"
+            )
+            lines1.append(
+                f"2026-03-10 12:00:01 | METRICS  | {json.dumps({'file': f'file{i}.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': status})}"
             )
         (log_dir1 / "task-100.log").write_text("\n".join(lines1))
 
@@ -364,7 +373,10 @@ class TestTaskProgress:
         lines2 = []
         for i in range(5):
             lines2.append(
-                f"2026-03-10 12:00:02 | METRICS | {json.dumps({'file': f'file{i}.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'success'})}"
+                f"2026-03-10 12:00:02 | INFO     | Starting processing:  file{i}.txt"
+            )
+            lines2.append(
+                f"2026-03-10 12:00:02 | METRICS  | {json.dumps({'file': f'file{i}.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'success'})}"
             )
         (log_dir2 / "task-100.log").write_text("\n".join(lines2))
 
@@ -442,7 +454,10 @@ class TestMultipleRuns:
         run1_lines = []
         for i in range(5):
             run1_lines.append(
-                f"2026-03-10 10:00:01 | METRICS | {json.dumps({'file': f'run1_file{i}.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'success'})}"
+                f"2026-03-10 10:00:01 | INFO     | Starting processing:  file{i}.txt"
+            )
+            run1_lines.append(
+                f"2026-03-10 10:00:01 | METRICS  | {json.dumps({'file': f'run1_file{i}.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'success'})}"
             )
             (finished / f"run1_file{i}.txt").touch()
         (log_dir1 / "task-100.log").write_text("\n".join(run1_lines))
@@ -453,7 +468,10 @@ class TestMultipleRuns:
         run2_lines = []
         for i in range(7):
             run2_lines.append(
-                f"2026-03-10 12:00:01 | METRICS | {json.dumps({'file': f'run2_file{i}.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'success'})}"
+                f"2026-03-10 12:00:01 | INFO     | Starting processing:  file{i}.txt"
+            )
+            run2_lines.append(
+                f"2026-03-10 12:00:01 | METRICS  | {json.dumps({'file': f'run2_file{i}.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'success'})}"
             )
             (finished / f"run2_file{i}.txt").touch()
         (log_dir2 / "task-200.log").write_text("\n".join(run2_lines))
@@ -488,14 +506,17 @@ class TestSlurmLogParsing:
         # Worker 1 processed file1
         worker1_log = log_dir / "task-worker-12345.log"
         worker1_log.write_text(
-            f"2026-03-10 12:00:01 | METRICS | {json.dumps({'file': 'file1.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'success'})}\n"
+            f"2026-03-10 12:00:01 | INFO     | Starting processing:  file1.txt\n"
+            f"2026-03-10 12:00:01 | METRICS  | {json.dumps({'file': 'file1.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'success'})}\n"
         )
 
         # Worker 2 processed file2 and file3
         worker2_log = log_dir / "task-worker-12346.log"
         worker2_log.write_text(
-            f"2026-03-10 12:00:02 | METRICS | {json.dumps({'file': 'file2.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'success'})}\n"
-            f"2026-03-10 12:00:03 | METRICS | {json.dumps({'file': 'file3.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'error'})}\n"
+            f"2026-03-10 12:00:02 | INFO     | Starting processing:  file2.txt\n"
+            f"2026-03-10 12:00:02 | METRICS  | {json.dumps({'file': 'file2.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'success'})}\n"
+            f"2026-03-10 12:00:03 | INFO     | Starting processing:  file3.txt\n"
+            f"2026-03-10 12:00:03 | METRICS  | {json.dumps({'file': 'file3.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'error'})}\n"
         )
 
         output = PipelineOutput(tmp_path)

--- a/tests/unit/cli/test_report.py
+++ b/tests/unit/cli/test_report.py
@@ -248,9 +248,6 @@ class TestAllRunsMetrics:
         all_lines = []
         for i in range(5):
             all_lines.append(
-                f"2026-03-10 10:00:01 | INFO     | Starting processing:  file{i}.txt"
-            )
-            all_lines.append(
                 f"2026-03-10 10:00:01 | METRICS  | {json.dumps({'file': f'file{i}.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'success'})}"
             )
         (log_dir / "task-12345.log").write_text("\n".join(all_lines))
@@ -305,9 +302,6 @@ class TestTaskProgress:
         for i in range(8):
             status = "success" if i < 6 else "error"
             task_lines.append(
-                f"2026-03-10 12:00:01 | INFO     | Starting processing:  file{i}.txt"
-            )
-            task_lines.append(
                 f"2026-03-10 12:00:01 | METRICS  | {json.dumps({'file': f'file{i}.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': status})}"
             )
         (log_dir / "task-100.log").write_text("\n".join(task_lines))
@@ -357,9 +351,6 @@ class TestTaskProgress:
         for i in range(10):
             status = "success" if i < 8 else "error"
             lines1.append(
-                f"2026-03-10 12:00:01 | INFO     | Starting processing:  file{i}.txt"
-            )
-            lines1.append(
                 f"2026-03-10 12:00:01 | METRICS  | {json.dumps({'file': f'file{i}.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': status})}"
             )
         (log_dir1 / "task-100.log").write_text("\n".join(lines1))
@@ -372,9 +363,6 @@ class TestTaskProgress:
         log_dir2.mkdir(parents=True)
         lines2 = []
         for i in range(5):
-            lines2.append(
-                f"2026-03-10 12:00:02 | INFO     | Starting processing:  file{i}.txt"
-            )
             lines2.append(
                 f"2026-03-10 12:00:02 | METRICS  | {json.dumps({'file': f'file{i}.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'success'})}"
             )
@@ -454,9 +442,6 @@ class TestMultipleRuns:
         run1_lines = []
         for i in range(5):
             run1_lines.append(
-                f"2026-03-10 10:00:01 | INFO     | Starting processing:  file{i}.txt"
-            )
-            run1_lines.append(
                 f"2026-03-10 10:00:01 | METRICS  | {json.dumps({'file': f'run1_file{i}.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'success'})}"
             )
             (finished / f"run1_file{i}.txt").touch()
@@ -467,9 +452,6 @@ class TestMultipleRuns:
         log_dir2.mkdir(parents=True)
         run2_lines = []
         for i in range(7):
-            run2_lines.append(
-                f"2026-03-10 12:00:01 | INFO     | Starting processing:  file{i}.txt"
-            )
             run2_lines.append(
                 f"2026-03-10 12:00:01 | METRICS  | {json.dumps({'file': f'run2_file{i}.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'success'})}"
             )
@@ -506,16 +488,13 @@ class TestSlurmLogParsing:
         # Worker 1 processed file1
         worker1_log = log_dir / "task-worker-12345.log"
         worker1_log.write_text(
-            f"2026-03-10 12:00:01 | INFO     | Starting processing:  file1.txt\n"
             f"2026-03-10 12:00:01 | METRICS  | {json.dumps({'file': 'file1.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'success'})}\n"
         )
 
         # Worker 2 processed file2 and file3
         worker2_log = log_dir / "task-worker-12346.log"
         worker2_log.write_text(
-            f"2026-03-10 12:00:02 | INFO     | Starting processing:  file2.txt\n"
             f"2026-03-10 12:00:02 | METRICS  | {json.dumps({'file': 'file2.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'success'})}\n"
-            f"2026-03-10 12:00:03 | INFO     | Starting processing:  file3.txt\n"
             f"2026-03-10 12:00:03 | METRICS  | {json.dumps({'file': 'file3.txt', 'started_at': now.isoformat(), 'finished_at': now.isoformat(), 'status': 'error'})}\n"
         )
 


### PR DESCRIPTION
Surfaces warnings found in the log files in the report dashboard:

<img width="727" height="323" alt="Screenshot 2026-08-26 at 3 52 30 PM" src="https://github.com/user-attachments/assets/469803cd-b851-4aff-9fbd-d167caeacffc" />

To do this, the log(s) are parsed, similarly to the `metrics` parsing, and each time `WARNING` is encountered, the count increases by one (unless the warning is about shutting down). In the same dictionary, a count is kept of the total number of files processed (using number of `METRICS` lines) to print the "across N file(s)" information. 


@yoonspark I plan to add some unit tests to this PR, but I just wanted to get your feedback on the design/approach before implementing those.

Closes #97 